### PR TITLE
fix(footer): remove opening in a new page from internal links

### DIFF
--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -60,7 +60,7 @@ export const Footer = () => {
             className="flex flex-col justify-end gap-4 pl-1 text-lg md:pl-20"
           >
             {NAV_LINKS.map(({ label, href }) => (
-              <Link className="font-mono" href={href} key={label} target="_blank">
+              <Link className="font-mono" href={href} key={label}>
                 {label}
               </Link>
             ))}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

Currently the footer page links open up a new tab, this is bad ux as it causes the user to collect extra tabs that are annoying to close and makes it feel like they're leaving the page.

I have reverted this functionality to keep the user in the same page when using the internal links.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

https://github.com/user-attachments/assets/92995e00-f1ad-44ff-a248-2a0baf631714

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member
