### PR TITLE
feat(components): add `Container` component

### DIFF
--- a/src/components/Primitive/Container/Container.stories.tsx
+++ b/src/components/Primitive/Container/Container.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Container } from "./Container"
+import { containerVariants } from "./Container.variants"
+
+const meta: Meta<typeof Container> = {
+  title: "Primitive Components/Container",
+  component: Container,
+  argTypes: {
+    children: { control: false },
+    theme: {
+      control: { type: "select" },
+      options: containerVariants.variants.theme
+        ? Object.keys(containerVariants.variants.theme)
+        : [],
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Container>
+
+export const Default: Story = {
+  args: {
+    children: <div className="px-6 py-6">This is a container</div>,
+    title: "Container Title",
+  },
+}

--- a/src/components/Primitive/Container/Container.tsx
+++ b/src/components/Primitive/Container/Container.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils"
+import { type ContainerVariantProps, containerVariants } from "./Container.variants"
+
+/**
+ *
+ */
+export interface ContainerProps extends ContainerVariantProps {
+  children: React.ReactNode
+  title?: string
+  className?: string
+}
+
+/**
+ *
+ * @param param0
+ * @returns
+ */
+export const Container = ({ children, title: titleText, className, theme }: ContainerProps) => {
+  const { container, title: titleClass } = containerVariants({ theme })
+  return (
+    <div className={cn(container(), className)}>
+      {titleText && <p className={titleClass()}>{titleText}</p>}
+      {children}
+    </div>
+  )
+}

--- a/src/components/Primitive/Container/Container.variants.ts
+++ b/src/components/Primitive/Container/Container.variants.ts
@@ -1,0 +1,41 @@
+import { tv, type VariantProps } from "tailwind-variants"
+
+/**
+ * Container variant configurations.
+ * Consists of themes for brand colours and sponsor tier colours.
+ */
+export const containerVariants = tv({
+  slots: {
+    container: "relative w-fit rounded-lg border-4",
+    title:
+      "-translate-x-1/2 -translate-y-1/2 absolute top-0 left-1/2 rounded-sm px-3 py-1 paragraph whitespace-nowrap max-w-full text-center font-semibold",
+  },
+  variants: {
+    theme: {
+      primary: {
+        container: "border-primary",
+        title: "bg-primary text-white",
+      },
+      diamond: {
+        container: "border-sponsor-diamond",
+        title: "bg-sponsor-diamond text-black",
+      },
+      gold: {
+        container: "border-sponsor-gold",
+        title: "bg-sponsor-gold text-black",
+      },
+      silver: {
+        container: "border-sponsor-silver",
+        title: "bg-sponsor-silver text-black",
+      },
+    },
+  },
+  defaultVariants: {
+    theme: "primary",
+  },
+})
+
+/**
+ * Props for the container variant configuration.
+ */
+export type ContainerVariantProps = VariantProps<typeof containerVariants>

--- a/src/components/Primitive/index.ts
+++ b/src/components/Primitive/index.ts
@@ -1,5 +1,6 @@
 export * from "./BorderButton/BorderButton"
 export * from "./Button/Button"
+export * from "./Container/Container"
 export * from "./Dropdown/Dropdown"
 export * from "./Heading/Heading"
 export * from "./LazyImage/LazyImage"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR introduces a new reusable `Container` primitive component, for use in the sponsors page and team page, as per the latest designs.
- the component lightly wraps children elements with a coloured border and an optional title that sits on the top of the border
- padding etc is left to be specified per use to maintain a primitive, and more reusable nature

Closes #98 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="410" height="187" alt="Screenshot 2026-02-01 at 00 46 00" src="https://github.com/user-attachments/assets/39963198-d4d5-4817-97bb-630013b4f854" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member
