### PR TITLE
feat(components): update `Footer` component to use latest designs

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -63,7 +63,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
           <Navbar links={navbarLinks} socialLinks={navbarSocialLinks} />
           <main className="flex flex-col items-center gap-14 py-9 md:gap-18">{children}</main>
         </div>
-        <Footer />
+        <Footer links={navbarLinks} socialLinks={navbarSocialLinks} />
       </body>
     </html>
   )

--- a/src/components/Composite/Footer/Footer.stories.tsx
+++ b/src/components/Composite/Footer/Footer.stories.tsx
@@ -1,9 +1,30 @@
+import { faDiscord, faInstagram, faLinkedin, faTiktok } from "@fortawesome/free-brands-svg-icons"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Footer } from "./Footer"
 
 const meta: Meta<typeof Footer> = {
   title: "Composite Components/Footer",
   component: Footer,
+  args: {
+    socialLinks: [
+      { label: "Discord", icon: faDiscord, href: "https://discord.gg/xSgqAmGE" },
+      { label: "Instagram", icon: faInstagram, href: "https://www.instagram.com/uoacs25/" },
+      { label: "TikTok", icon: faTiktok, href: "https://www.tiktok.com/@uoacs?lang=en-GB" },
+      {
+        label: "LinkedIn",
+        icon: faLinkedin,
+        href: "https://www.linkedin.com/company/university-of-auckland-compsci-society/posts/?feedView=all",
+      },
+    ],
+    links: [
+      { label: "MEET THE TEAM", href: "/team" },
+      { label: "OUR SPONSORS", href: "/sponsors" },
+    ],
+  },
+  argTypes: {
+    links: { control: "object" },
+    socialLinks: { control: "object" },
+  },
 }
 
 export default meta

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -73,10 +73,7 @@ export const Footer = ({ links, socialLinks }: FooterProps) => {
         </nav>
       </div>
 
-      <nav
-        aria-label="Footer navigation"
-        className="hidden flex-col justify-end gap-4 pl-1 text-lg md:flex md:pl-20"
-      >
+      <nav aria-label="Footer navigation" className="hidden flex-col items-start gap-4 md:flex">
         <p className="paragraph-sm text-gray-400">Pages</p>
         {links.map(({ label, href }) => (
           <Link className="w-fit" href={href} key={label}>

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -7,6 +7,7 @@ import Link from "next/link"
 import { Button } from "@/components/Primitive"
 import { cn } from "@/lib/utils"
 import type { SocialLink } from "../Navbar/Navbar"
+import { NavbarGradient } from "../Navbar/NavbarGradient"
 
 /**
  * Props for the {@link Footer} component
@@ -52,7 +53,8 @@ const InterestedButton = ({ className }: { className?: string }) => (
  */
 export const Footer = ({ links, socialLinks }: FooterProps) => {
   return (
-    <footer className="grid w-full grid-cols-1 gap-4 bg-gray-800 p-5 text-white md:grid-cols-4 md:p-6">
+    <footer className="relative grid w-full grid-cols-1 gap-4 bg-gray-800 p-5 text-white md:grid-cols-4 md:p-6">
+      <NavbarGradient className="h-full translate-y-2/3 md:h-full md:translate-y-5/6" />
       <div className="flex flex-col gap-4">
         <div className="flex flex-row flex-wrap items-start justify-between gap-2">
           <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -1,93 +1,108 @@
-import { faDiscord, faInstagram, faLinkedin, faTiktok } from "@fortawesome/free-brands-svg-icons"
+"use client"
+
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import Image from "next/image"
+import { ArrowUpRightIcon } from "@heroicons/react/24/solid"
+import { motion } from "motion/react"
 import Link from "next/link"
-import { BorderButton } from "@/components/Primitive"
+import { Button } from "@/components/Primitive"
+import { cn } from "@/lib/utils"
+import type { SocialLink } from "../Navbar/Navbar"
 
-const SOCIAL_LINKS = [
-  { icon: faDiscord, label: "Discord", href: "https://discord.gg/xSgqAmGE" },
-  { icon: faInstagram, label: "Instagram", href: "https://www.instagram.com/uoacs25/" },
-  { icon: faTiktok, label: "TikTok", href: "https://www.tiktok.com/@uoacs?lang=en-GB" },
-  {
-    icon: faLinkedin,
-    label: "LinkedIn",
-    href: "https://www.linkedin.com/company/university-of-auckland-compsci-society/posts/?feedView=all",
-  },
-] as const
+/**
+ * Props for the {@link Footer} component
+ */
+export interface FooterProps {
+  /**
+   * Links to be displayed in the center of the navbar.
+   */
+  links: { label: string; href: string }[]
+  /**
+   * Social links to be displayed in the dropdown on the right of the navbar's middle.
+   */
+  socialLinks: SocialLink[]
+}
 
-const NAV_LINKS = [
-  { label: "Home", href: "/" },
-  { label: "Meet the team", href: "/team" },
-  { label: "Our sponsors", href: "/sponsors" },
-] as const
+/**
+ * Reusable button component to be used in the Footer
+ * Extracted to ensure consistency, and avoid code duplication
+ *
+ * @param className optional additional class names to apply to the button
+ */
+const InterestedButton = ({ className }: { className?: string }) => (
+  <a
+    href="https://docs.google.com/forms/d/e/1FAIpQLSdV530DNIMfGaQJwllWgLq22gsZpIutlHU2NwImHjmJyjWrQQ/viewform"
+    rel="noopener"
+    target="_blank"
+  >
+    <Button
+      className={cn("whitespace-nowrap", className)}
+      right={<ArrowUpRightIcon className="h-4 w-4 text-white" />}
+      theme="primary"
+    >
+      Interested? Join UOACS
+    </Button>
+  </a>
+)
 
-export const Footer = () => {
+/**
+ * A footer component for the website, containing links and social media icons.
+ *
+ * @param links Links to be displayed in the center of the navbar.
+ * @param socialLinks Social links to be displayed in the dropdown on the right of the navbar's middle.
+ */
+export const Footer = ({ links, socialLinks }: FooterProps) => {
   return (
-    <footer className="relative min-h-72 w-full overflow-hidden bg-gray-800 p-7 text-white">
-      <div className="flex min-h-64 flex-col">
-        <nav aria-label="Social media links" className="flex items-start gap-4">
-          {SOCIAL_LINKS.map(({ icon, label, href }) => (
-            <BorderButton
-              aria-label={label}
-              key={label}
-              variant={{ border: true, size: "sm", theme: "primary" }}
-            >
-              <a
-                aria-label={`Visit our ${label}`}
-                href={href}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <FontAwesomeIcon className="md:text-3xl" fontSize={24} icon={icon} />
-              </a>
-            </BorderButton>
-          ))}
-        </nav>
-
-        <div className="flex flex-1 flex-col items-start gap-4 md:flex-row md:items-end md:gap-8">
-          <div className="mb-10 flex">
-            <Image
-              alt="UOACS Logo"
-              className="mt-8 md:mt-0"
-              height={150}
-              src="/uoacs-logo.svg"
-              width={150}
-            />
-          </div>
-
-          <nav
-            aria-label="Footer navigation"
-            className="flex flex-col justify-end gap-4 pl-1 text-lg md:pl-20"
-          >
-            {NAV_LINKS.map(({ label, href }) => (
-              <Link className="font-mono" href={href} key={label}>
-                {label}
-              </Link>
-            ))}
-          </nav>
-
-          <div className="relative z-10 mt-8 flex flex-1 items-end justify-start md:justify-end">
+    <footer className="grid w-full grid-cols-1 gap-4 bg-gray-800 p-5 text-white md:grid-cols-4 md:p-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-row flex-wrap items-start justify-between gap-2">
+          <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>
+          <InterestedButton className="md:hidden" />
+        </div>
+        <nav aria-label="Social media links" className="flex flex-row items-start gap-4">
+          {socialLinks.map(({ icon, label, href }) => (
             <a
-              href="https://docs.google.com/forms/d/e/1FAIpQLSdV530DNIMfGaQJwllWgLq22gsZpIutlHU2NwImHjmJyjWrQQ/viewform"
-              rel="noopener"
+              aria-label={`Visit our ${label}`}
+              href={href}
+              key={label}
+              rel="noopener noreferrer"
               target="_blank"
             >
-              <BorderButton variant={{ border: true, size: "sm", theme: "primary" }}>
-                INTERESTED? JOIN US
-              </BorderButton>
+              <FontAwesomeIcon className="md:text-2xl" fontSize={20} icon={icon} />
             </a>
-          </div>
-        </div>
+          ))}
+        </nav>
       </div>
 
-      <Image
-        alt="Background Gradient"
-        aria-hidden="true"
-        className="pointer-events-none absolute right-0 bottom-0 w-full md:max-w-[60%]"
-        height={850}
-        src="/uoacs-gradient.svg"
-        width={850}
-      />
+      <nav
+        aria-label="Footer navigation"
+        className="hidden flex-col justify-end gap-4 pl-1 text-lg md:flex md:pl-20"
+      >
+        <p className="paragraph-sm text-gray-400">Pages</p>
+        {links.map(({ label, href }) => (
+          <Link className="w-fit" href={href} key={label}>
+            <motion.div initial="initial" whileHover="hover">
+              <p className="paragraph-sm font-medium">{label}</p>
+              <motion.div
+                className="h-px bg-gray-300"
+                variants={{
+                  initial: {
+                    width: "0px",
+                  },
+                  hover: {
+                    width: "100%",
+                  },
+                }}
+              />
+            </motion.div>
+          </Link>
+        ))}
+      </nav>
+
+      <div className="hidden md:block" />
+
+      <div className="relative hidden md:block">
+        <InterestedButton className="absolute top-0 right-0" />
+      </div>
     </footer>
   )
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR updates the `Footer` component to use the latest designs:
 - updates the structure to follow the grid pattern, and collapse into a flex container on mobile
 - adds a hover animation to the page links
 - adds a gradient above the footer, which resizes upon collapse to fit similarly

Closes #88 

### Type of change:
<!-- Please delete options that are not relevant. -->

<img width="1912" height="1242" alt="Screenshot 2026-02-06 at 21 53 20" src="https://github.com/user-attachments/assets/f42d10ed-be1a-4e0d-a3b9-6b4227aef1e1" />
<img width="612" height="1242" alt="Screenshot 2026-02-06 at 21 53 37" src="https://github.com/user-attachments/assets/79be8a47-364d-4238-a447-94cce82496bd" />


- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> [!NOTE]
> Please check that the gradient isn't messing up the formatting
> I had lots of issues with the gradient being exposed below the dark footer
> I think these were fixed, but the layout is pretty janky, with it just being a hardcoded translation

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
