### PR TITLE
fix(values-section): increase accordion width and improve responsiveness

### DIFF
--- a/src/components/Composite/ValuesSection/ValuesSection.tsx
+++ b/src/components/Composite/ValuesSection/ValuesSection.tsx
@@ -11,7 +11,7 @@ export const ValuesSection = () => {
           <Heading h={2}>Our Values</Heading>
           <Image
             alt="react fragment"
-            className="-right-20 -top-4 absolute"
+            className="-translate-y-1/2 absolute top-0 right-0 h-12 w-12 translate-x-full md:h-16 md:w-16"
             height={75}
             src="/react-fragment.svg"
             width={75}

--- a/src/components/Generic/ValuesAccordion/ValuesAccordion.tsx
+++ b/src/components/Generic/ValuesAccordion/ValuesAccordion.tsx
@@ -19,7 +19,7 @@ export interface ValuesAccordionProps {
 export const ValuesAccordion = ({ values }: ValuesAccordionProps) => {
   const [openIndex, setOpenIndex] = useState<number | null>(null)
   return (
-    <div className="w-full max-w-[30rem]">
+    <div className="w-full max-w-[40rem]">
       {values.map((value, index) => (
         <ValuesAccordionItem
           isOpen={openIndex === index}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR updates the `ValuesAccordion` component to use the updated max width of 600px, and adds responsiveness to the react fragment icon, via size-relative positioning and responsive scaling.

### Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
