### PR TITLE
fix(who-we-are-section): fix horizontal overflow on mobile devices

### DIFF
--- a/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
+++ b/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
@@ -38,7 +38,7 @@ export const WhoWeAreSection = ({ polaroids }: WhoWeAreSectionProps) => {
     const updateScale = () => {
       if (containerRef.current) {
         const containerWidth = containerRef.current.offsetWidth
-        setScale(Math.min(1, containerWidth / BASE_WIDTH))
+        setScale(Math.min(1, containerWidth / (1.1 * BASE_WIDTH)))
       }
     }
     updateScale()
@@ -93,7 +93,7 @@ export const WhoWeAreSection = ({ polaroids }: WhoWeAreSectionProps) => {
           style={{ height: BASE_HEIGHT * scale }}
         >
           <div
-            className="-left-5 relative origin-top-left"
+            className="relative origin-top-left"
             style={{
               width: BASE_WIDTH,
               height: BASE_HEIGHT,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR ***actually*** fixes the home page overflow problem by addressing overflow in the absolutely positioned polaroids. THIS IS VERY JANK, but i think it fixes it this time. had to setup ngrok to test on my phone since devtools thought i had already fixed it, but i think it works now for most devices.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)