### PR TITLE
fix(navbar): use href as React key for dropdown options

### DIFF
--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -103,7 +103,7 @@ export const Dropdown = ({
           >
             {options.map((option) => (
               <motion.div
-                key={option.label?.toString()}
+                key={option.href ?? option.label?.toString()}
                 variants={{
                   open: { opacity: 1, y: 0 },
                   closed: { opacity: 0, y: -5 },


### PR DESCRIPTION
## Summary

- Fixes duplicate React key warning in the Navbar socials dropdown
- `option.label?.toString()` returns `"[object Object]"` when label is a JSX element, making all 4 social links share the same key
- Uses `option.href` as the key instead (guaranteed unique per social link), falling back to the label string for non-link options

## Change

Single-line change in `src/components/Primitive/Dropdown/Dropdown.tsx`:

```diff
- key={option.label?.toString()}
+ key={option.href ?? option.label?.toString()}
```

## Test plan

- [ ] Open homepage — Next.js "1 Issue" overlay is gone
- [ ] Console has no "Encountered two children with the same key" error
- [ ] Socials dropdown opens and shows all 4 items correctly