### PR TITLE
fix(hero): replace BorderButton+<a> nesting with <a> using borderButtonVariants

### DIFF
--- a/src/components/Composite/HeroSection/HeroSection.tsx
+++ b/src/components/Composite/HeroSection/HeroSection.tsx
@@ -1,4 +1,5 @@
-import { BorderButton, Heading, SOCIAL_ICONS, SocialIcon } from "@/components/Primitive"
+import { Heading, SOCIAL_ICONS, SocialIcon } from "@/components/Primitive"
+import { borderButtonVariants } from "@/components/Primitive/BorderButton/variants"
 
 /**
  * HeroSection component for the homepage.
@@ -54,22 +55,27 @@ export const HeroSection = () => {
           aria-label="Social media links"
           className="flex w-fit items-start gap-2 self-center md:gap-4 md:self-start"
         >
-          {SOCIAL_LINKS.map(({ icon, label, href }) => (
-            <BorderButton
-              aria-label={label}
-              key={label}
-              variant={{ border: true, size: "sm", theme: "primary" }}
-            >
+          {SOCIAL_LINKS.map(({ icon, label, href }) => {
+            const { border, inner } = borderButtonVariants({
+              border: true,
+              size: "sm",
+              theme: "primary",
+            })
+            return (
               <a
                 aria-label={`Visit our ${label}`}
+                className={border()}
                 href={href}
+                key={label}
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                <SocialIcon className="h-6 w-6 md:h-7 md:w-7" icon={icon} />
+                <div className={inner()}>
+                  <SocialIcon className="h-6 w-6 md:h-7 md:w-7" icon={icon} />
+                </div>
               </a>
-            </BorderButton>
-          ))}
+            )
+          })}
         </nav>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Fixes invalid HTML: `<button>` (from `BorderButton`) was wrapping `<a>` for each social icon in the hero section
- Interactive elements cannot nest inside `<button>` — this violates the HTML spec and triggers browser warnings
- Applies `borderButtonVariants` classes directly to the `<a>` element, preserving identical visual appearance

## Change

`src/components/Composite/HeroSection/HeroSection.tsx`

- Replace `BorderButton` + nested `<a>` with `<a className={border()}>` + `<div className={inner()}>` using `borderButtonVariants({ border: true, size: "sm", theme: "primary" })`
- Remove unused `BorderButton` import; add `borderButtonVariants` import from `@/components/Primitive/BorderButton/variants`

## Test plan

- [ ] Inspect hero section social icons in DevTools — each icon is an `<a>` element with no `<button>` wrapper
- [ ] Visual appearance is identical (same pink bordered square styling)
- [ ] Clicking each icon navigates to the correct external URL in a new tab
- [ ] No HTML validation errors in the hero section