### PR TITLE
feat(staging): implement a seperate staging db and bucket, and clean up workflows

### DIFF
--- a/.github/actions/fly-deploy/action.yaml
+++ b/.github/actions/fly-deploy/action.yaml
@@ -15,10 +15,6 @@ inputs:
     description: 'Name of the Fly.io application'
     required: false
     default: ''
-  ENVIRONMENT:
-    description: 'Deployment environment (staging or prod)'
-    required: false
-    default: 'staging'
   # Build Secrets
   DATABASE_URI:
     description: 'Database connection URI'

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -2,9 +2,9 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [main, production]
+    branches: [main, release/*]
   pull_request:
-    branches: [main, production]
+    branches: [main, release/*]
 
 jobs:
   lint:

--- a/.github/workflows/fly-deploy-staging.yaml
+++ b/.github/workflows/fly-deploy-staging.yaml
@@ -22,7 +22,6 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           APP_NAME: uoacs-website-staging
           CONFIG_FILE: fly.staging.toml
-          ENVIRONMENT: staging
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -22,7 +22,6 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           APP_NAME: uoacs-website
           CONFIG_FILE: fly.toml
-          ENVIRONMENT: prod
           DATABASE_URI: ${{ secrets.DATABASE_URI }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           NEXT_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_URL }}


### PR DESCRIPTION
# Description
   
This PR bundles a couple small fixes across CI configuration, deployment workflows.
 - updates the CI pipeline to run on release/* branches instead of production
 - removes the unused ENVIRONMENT input from the fly-deploy action and its callers (fly-deploy-staging.yaml and fly-deploy.yml)

Additionally, outside of the PR, I have created and set up a staging db and bucket which should be used for local development and within the staging environment [joshli.uoacs.co.nz](joshli.uoacs.co.nz)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

