### PR TITLE
fix(reels): ensure landscape videos arent cut off

### DIFF
--- a/src/components/Composite/Reel/Reel.tsx
+++ b/src/components/Composite/Reel/Reel.tsx
@@ -27,11 +27,11 @@ export const Reel = ({ reel }: ReelProps) => {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
   return (
-    <div className="relative h-128 min-w-72 cursor-pointer overflow-hidden rounded-xl">
+    <div className="relative h-128 min-w-72 cursor-pointer overflow-hidden rounded-xl bg-gray-900">
       <video
         aria-label={`Instagram Reel: ${reel.description}`}
         autoPlay
-        className="absolute inset-0 h-full w-full cursor-default object-cover"
+        className="absolute inset-0 my-auto w-full cursor-default object-cover"
         loop
         muted
         playsInline


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes landscape (horizontal) videos in the Reel component being cut off.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<img width="1912" height="1242" alt="Screenshot 2026-02-20 at 13 42 51" src="https://github.com/user-attachments/assets/4054a72f-9619-490e-8754-80d02602121e" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

