### PR TITLE
feat(payload): revalidate next cache on admin changes

### DIFF
--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,7 @@
+export const Routes = {
+  home: "/",
+  team: "/team",
+  sponsors: "/sponsors",
+} as const
+
+export type Route = (typeof Routes)[keyof typeof Routes]

--- a/src/payload/collections/Executive.ts
+++ b/src/payload/collections/Executive.ts
@@ -1,5 +1,9 @@
 import type { CollectionConfig } from "payload"
+import { Routes } from "@/lib/routes"
 import { ExecutiveLevel, ExecutiveTeam } from "@/types/enums"
+import { makeRevalidateHooks } from "../hooks/revalidate"
+
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.team])
 
 export const Executive: CollectionConfig = {
   slug: "executive",
@@ -81,4 +85,5 @@ export const Executive: CollectionConfig = {
       },
     },
   ],
+  hooks: { afterChange: [afterChange], afterDelete: [afterDelete] },
 }

--- a/src/payload/collections/Polaroid.ts
+++ b/src/payload/collections/Polaroid.ts
@@ -1,4 +1,8 @@
 import type { CollectionConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { makeRevalidateHooks } from "../hooks/revalidate"
+
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
 
 export const Polaroid: CollectionConfig = {
   slug: "polaroid",
@@ -27,4 +31,5 @@ export const Polaroid: CollectionConfig = {
       },
     },
   ],
+  hooks: { afterChange: [afterChange], afterDelete: [afterDelete] },
 }

--- a/src/payload/collections/Reel.ts
+++ b/src/payload/collections/Reel.ts
@@ -1,4 +1,8 @@
 import type { CollectionConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { makeRevalidateHooks } from "../hooks/revalidate"
+
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
 
 export const Reel: CollectionConfig = {
   slug: "reel",
@@ -27,4 +31,5 @@ export const Reel: CollectionConfig = {
       },
     },
   ],
+  hooks: { afterChange: [afterChange], afterDelete: [afterDelete] },
 }

--- a/src/payload/collections/Sponsor.ts
+++ b/src/payload/collections/Sponsor.ts
@@ -1,5 +1,9 @@
 import type { CollectionConfig } from "payload"
+import { Routes } from "@/lib/routes"
 import { SponsorTier } from "@/types/enums"
+import { makeRevalidateHooks } from "../hooks/revalidate"
+
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.sponsors, Routes.home])
 
 export const Sponsor: CollectionConfig = {
   slug: "sponsor",
@@ -45,4 +49,5 @@ export const Sponsor: CollectionConfig = {
       },
     },
   ],
+  hooks: { afterChange: [afterChange], afterDelete: [afterDelete] },
 }

--- a/src/payload/globals/HomePage.ts
+++ b/src/payload/globals/HomePage.ts
@@ -1,4 +1,8 @@
 import type { GlobalConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
+
+const { globalAfterChange } = makeRevalidateHooks([Routes.home])
 
 export const HomePage: GlobalConfig = {
   slug: "home-page",
@@ -21,4 +25,5 @@ export const HomePage: GlobalConfig = {
       maxRows: 3,
     },
   ],
+  hooks: { afterChange: [globalAfterChange] },
 }

--- a/src/payload/hooks/revalidate.ts
+++ b/src/payload/hooks/revalidate.ts
@@ -1,0 +1,37 @@
+import { revalidatePath } from "next/cache"
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+  GlobalAfterChangeHook,
+} from "payload"
+import type { Route } from "@/lib/routes"
+
+const revalidateRoutes = (
+  routes: Route[],
+  payload: { logger: { info: (msg: string) => void } },
+): void => {
+  for (const route of routes) {
+    payload.logger.info(`Revalidating ${route}`)
+    revalidatePath(route)
+  }
+}
+
+export const makeRevalidateHooks = (
+  routes: Route[],
+): {
+  afterChange: CollectionAfterChangeHook
+  afterDelete: CollectionAfterDeleteHook
+  globalAfterChange: GlobalAfterChangeHook
+} => ({
+  afterChange: (({ req: { payload } }) => {
+    revalidateRoutes(routes, payload)
+  }) satisfies CollectionAfterChangeHook,
+
+  afterDelete: (({ req: { payload } }) => {
+    revalidateRoutes(routes, payload)
+  }) satisfies CollectionAfterDeleteHook,
+
+  globalAfterChange: (({ req: { payload } }) => {
+    revalidateRoutes(routes, payload)
+  }) satisfies GlobalAfterChangeHook,
+})


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR adds on-demand cache revalidation via Payload afterChange/afterDelete hooks so that frontend pages update in production without a redeploy.
                                                                                                                                                                                  
Next.js statically generates /, /team, and /sponsors at build time (no dynamic functions or fetch with no-store are used). Without this, admin changes are invisible in production until the next deploy.

- introduces src/lib/routes.ts with a Routes constant and Route type for all frontend paths
- introduces src/payload/hooks/revalidate.ts with a makeRevalidateHooks() factory that returns typed afterChange, afterDelete, and globalAfterChange hooks — each calls  revalidatePath() for the specified routes
- wires these hooks into collections and globals

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

https://github.com/user-attachments/assets/61de20d0-9b81-407c-a6f4-6129d087d35e

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
