### PR TITLE
feat(notifications): add images and release discord notifications

### DIFF
--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -3,6 +3,8 @@ name: PR Notification
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, closed]
+  release:
+    types: [published]
 
 jobs:
   notify:
@@ -13,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Send notification for PR Ready for Review
-        if: github.event.pull_request.draft == false && (github.event.action == 'ready_for_review' || github.event.action == 'opened' || github.event.action == 'reopened')
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && (github.event.action == 'ready_for_review' || github.event.action == 'opened' || github.event.action == 'reopened')
         uses: taroj1205/discord-notification@v1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -30,7 +32,7 @@ jobs:
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
       - name: Send notification on PR Merged
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         uses: taroj1205/discord-notification@v1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -46,7 +48,7 @@ jobs:
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
       - name: Send notification on PR Closed
-        if: github.event.action == 'closed' && github.event.pull_request.merged == false
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
         uses: taroj1205/discord-notification@v1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -59,3 +61,19 @@ jobs:
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
           image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
           button_label: 'View Closed PR'
+
+      - name: Send notification on New Release
+        if: github.event_name == 'release'
+        uses: taroj1205/discord-notification@v1
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          color: 5763719
+          title: 'New Release: ${{ github.event.release.tag_name }}'
+          description: ${{ github.event.release.body }}
+          description_max_length: 175
+          url: ${{ github.event.release.html_url }}
+          author_name: ${{ github.event.release.author.login }}
+          author_url: ${{ github.event.release.author.html_url }}
+          author_icon_url: ${{ github.event.release.author.avatar_url }}
+          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
+          button_label: 'View Release'

--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: taroj1205/discord-notification@v1
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          color: 5763719
+          color: 3447003
           title: 'New Release: ${{ github.event.release.tag_name }}'
           description: ${{ github.event.release.body }}
           description_max_length: 175

--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -27,7 +27,7 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
-          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
+          image_url: 'https://opengraph.githubassets.com/${{ github.sha }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           button_label: 'View Pull Request'
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
@@ -43,7 +43,7 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
-          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
+          image_url: 'https://opengraph.githubassets.com/${{ github.sha }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           button_label: 'View Merged PR'
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
@@ -59,7 +59,7 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
-          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
+          image_url: 'https://opengraph.githubassets.com/${{ github.sha }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           button_label: 'View Closed PR'
 
       - name: Send notification on New Release
@@ -75,5 +75,5 @@ jobs:
           author_name: ${{ github.event.release.author.login }}
           author_url: ${{ github.event.release.author.html_url }}
           author_icon_url: ${{ github.event.release.author.avatar_url }}
-          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
+          image_url: 'https://opengraph.githubassets.com/${{ github.sha }}/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}'
           button_label: 'View Release'

--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -25,6 +25,7 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
+          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
           button_label: 'View Pull Request'
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
@@ -40,6 +41,7 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
+          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
           button_label: 'View Merged PR'
           branch_info: '`${{ github.event.pull_request.head.ref }}` -> `${{ github.event.pull_request.base.ref }}`'
 
@@ -55,4 +57,5 @@ jobs:
           author_name: ${{ github.event.pull_request.user.login }}
           author_url: ${{ github.event.pull_request.user.html_url }}
           author_icon_url: ${{ github.event.pull_request.user.avatar_url }}
+          image_url: https://opengraph.githubassets.com/1/${{ github.repository }}
           button_label: 'View Closed PR'


### PR DESCRIPTION
## Summary
- Adds `image_url` to all existing PR Discord notification steps, using GitHub's public OG image for the repo (previously unused as the repo was private)
- Adds a new `release: types: [published]` trigger to the existing `notification.yaml` workflow
- Adds a release notification step that fires when a GitHub Release is published, including the release tag, notes, author, and repo image
- Guards all existing PR steps with `github.event_name == 'pull_request'` to prevent them firing on release events

## Test plan
- [ ] Open/reopen a PR and confirm the Discord notification includes the repo OG image
- [ ] Merge a PR and confirm the merged notification includes the repo OG image
- [ ] Publish a draft GitHub Release and confirm a green Discord embed appears with the release tag, notes, and image