### PR TITLE
fix(navbar): set dropdown icons to fit height, avoiding overlap between options

### DIFF
--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -109,10 +109,10 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
               <Button className="col-span-4 rounded-b-none" theme="dark">
                 Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
               </Button>
-              <div className="bg-orange-400 h-0.5 w-full rounded-bl-[2px]" />
-              <div className="bg-blue-400 h-0.5 w-full" />
-              <div className="bg-purple-400 h-0.5 w-full" />
-              <div className="bg-pink-400 h-0.5 w-full rounded-br-[2px]" />
+              <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+              <div className="h-0.5 w-full bg-blue-400" />
+              <div className="h-0.5 w-full bg-purple-400" />
+              <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
             </a>
           </motion.div>
         )}

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -45,7 +45,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
     label: (
       <span className="flex items-center gap-2">
         {socialLink.label}
-        <SocialIcon className="w-4 h-fit" icon={socialLink.icon} />
+        <SocialIcon className="h-fit w-4" icon={socialLink.icon} />
       </span>
     ),
     href: socialLink.href,
@@ -62,7 +62,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
           </Link>
         </motion.div>
         <MobileNavbar links={links} socialLinks={socialLinks} />
-        <div className="nowrap flex hidden flex-row gap-5 md:flex">
+        <div className="nowrap hidden flex-row gap-5 md:flex">
           <div className="flex flex-row items-center gap-5">
             {links
               .filter((link) => link.label.toLowerCase() !== "home")

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -45,7 +45,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
     label: (
       <span className="flex items-center gap-2">
         {socialLink.label}
-        <SocialIcon className="w-4" icon={socialLink.icon} />
+        <SocialIcon className="w-4 h-fit" icon={socialLink.icon} />
       </span>
     ),
     href: socialLink.href,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes an issue with the dropdown links having a height far larger than their visible size, causing it to be extremely difficult and confusing to click on the correct link. This was caused by an unbounded height on the social icons, combined with the relative positioning, allowing the `<a>` areas to overlap.

## Type of change
<!-- Please delete options that are not relevant. -->
<img width="333" height="208" alt="Screenshot 2026-02-25 at 10 38 22" src="https://github.com/user-attachments/assets/c9ba75bf-26c5-42e1-9640-ae1e60f93150" />

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
<img width="333" height="208" alt="Screenshot 2026-02-25 at 10 38 46" src="https://github.com/user-attachments/assets/1aa76bbd-8aec-47aa-b9d1-691b441f5195" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

