### PR TITLE
feat(sponsors-section): add colour palette to corners of header

### DIFF
--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -2,6 +2,7 @@ import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { SponsorTicker } from "@/components/Generic"
 import { Button, Heading } from "@/components/Primitive"
+import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
 
 /**
@@ -15,6 +16,22 @@ export interface SponsorsSectionProps {
 }
 
 /**
+ * @param className Additional class names to apply to the colour palette container
+ * @warning Unless `absolute` positioning is overridden, a `bottom` or `top` and a `left` or `right` class must be provided to position the palette correctly within the section
+ */
+const ColourPalette = ({ className }: { className: string }) => {
+  return (
+    <div className={cn("absolute grid h-3 w-44 grid-cols-5", className)}>
+      <div className="bg-brand-orange" />
+      <div className="bg-brand-blue" />
+      <div className="bg-brand-purple" />
+      <div className="bg-brand-pink" />
+      <div className="bg-black" />
+    </div>
+  )
+}
+
+/**
  * A section component that displays sponsors with a heading, description, ticker, and link to all sponsors
  *
  * @param sponsors An array of sponsor documents to display in the section
@@ -22,11 +39,13 @@ export interface SponsorsSectionProps {
 export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
   return (
     <div className="flex max-w-360 flex-col items-center justify-center gap-6 overflow-hidden md:gap-12">
-      <div className="flex flex-col items-center gap-6 px-4 text-center">
+      <div className="relative flex flex-col items-center gap-6 px-4 py-12 text-center md:py-12">
+        <ColourPalette className="top-0 right-0" />
         <Heading h={2}>Sponsored By</Heading>
         <p className="paragraph">
           These are the people that support us and make this club possible.
         </p>
+        <ColourPalette className="bottom-0 left-0 hidden md:grid" />
       </div>
       <SponsorTicker containerClassName="max-w-360" items={sponsors} />
       <Link href="/sponsors">

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -43,7 +43,8 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
         <ColourPalette className="top-0 right-0" />
         <Heading h={2}>Sponsored By</Heading>
         <p className="paragraph">
-          These are the people that support us and make this club possible.
+          These are the people that support us and make this club{" "}
+          <span className="text-brand-pink">possible</span>
         </p>
         <ColourPalette className="bottom-0 left-0 hidden md:grid" />
       </div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR adds a colour palette to the corners of the header in the SponsorsSection component and colours the word "possible" in the subtitle pink.
  - introduces a ColourPalette sub-component that renders five brand colour swatches (bg-brand-orange, bg-brand-blue, bg-brand-purple, bg-brand-pink, bg-black)
   in a horizontal strip
  - adds two ColourPalette instances to the section header — one in the top-right corner and one in the bottom-left (hidden below md breakpoint)
  - wraps "possible" in the subtitle with text-brand-pink

  Closes #92

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="990" height="576" alt="Screenshot 2026-02-27 at 00 52 18" src="https://github.com/user-attachments/assets/c2a6ee98-4488-4345-a370-9286f1a4b8f3" />
<img width="477" height="491" alt="Screenshot 2026-02-27 at 00 52 35" src="https://github.com/user-attachments/assets/f0bff024-c4a0-4a00-8ef3-deaf90c689d4" />


- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
