### PR TITLE
feat(exec-card): add LinkedIn link with hover state

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   return (
     <html className={`${inter.variable} ${switzer.variable} overflow-x-hidden`} lang="en">
       <body className="relative overflow-x-hidden">
-        <div className="mx-auto flex w-full max-w-360 flex-col gap-14 px-4 py-6 md:gap-9 md:px-12 lg:px-20">
+        <div className="mx-auto flex w-full max-w-[1480px] flex-col gap-14 px-4 py-6 md:gap-9 md:px-12 lg:px-20">
           <Navbar links={navbarLinks} socialLinks={navbarSocialLinks} />
           <main className="flex flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
         </div>

--- a/src/components/Generic/ExecCard/ExecCard.stories.tsx
+++ b/src/components/Generic/ExecCard/ExecCard.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
-import { mockExecutive, mockExecutiveWithPhoto } from "@/mocks/Executive.mock"
+import {
+  mockExecutive,
+  mockExecutiveWithLinkedin,
+  mockExecutiveWithLinkedinFallback,
+  mockExecutiveWithPhoto,
+} from "@/mocks/Executive.mock"
 import { ExecCard, type ExecCardProps } from "./ExecCard"
 
 const meta: Meta<ExecCardProps> = {
@@ -19,5 +24,17 @@ export const Default: Story = {}
 export const Fallback: Story = {
   args: {
     exec: mockExecutive,
+  },
+}
+
+export const WithLinkedIn: Story = {
+  args: {
+    exec: mockExecutiveWithLinkedin,
+  },
+}
+
+export const FallbackWithLinkedIn: Story = {
+  args: {
+    exec: mockExecutiveWithLinkedinFallback,
   },
 }

--- a/src/components/Generic/ExecCard/ExecCard.tsx
+++ b/src/components/Generic/ExecCard/ExecCard.tsx
@@ -18,19 +18,19 @@ export const ExecCard = ({ exec }: ExecCardProps) => {
     src = maybeMedia.url ?? maybeMedia.thumbnailURL ?? undefined
   }
 
-  return (
-    <div className="flex w-[6.75rem] flex-col items-start gap-2 md:w-[12.5rem] md:gap-3">
+  const photoSquare = (
+    <div className="relative h-[6.75rem] w-[6.75rem] overflow-hidden rounded-md md:h-[12.5rem] md:w-[12.5rem]">
       {src ? (
         <Image
           alt={`${exec.name} photo`}
-          className="size-full h-[6.75rem] w-[6.75rem] rounded-md object-cover md:h-[12.5rem] md:w-[12.5rem]"
+          className="size-full object-cover"
           height={200}
           priority
           src={src}
           width={200}
         />
       ) : (
-        <p className="flex aspect-square size-full h-[6.75rem] w-[6.75rem] items-center justify-center rounded-md bg-gray-200 font-md text-gray-700 text-xl md:h-[12.5rem] md:w-[12.5rem]">
+        <p className="flex aspect-square size-full items-center justify-center bg-gray-200 font-md text-gray-700 text-xl">
           {exec.name
             ? exec.name
                 .split(" ")
@@ -40,12 +40,37 @@ export const ExecCard = ({ exec }: ExecCardProps) => {
             : ""}
         </p>
       )}
-      <div className="flex flex-col items-start gap-1">
-        <p className="paragraph">{exec.name}</p>
-        {exec.role.title && (
-          <p className="paragraph-xs font-medium text-gray-500">{exec.role.title}</p>
-        )}
-      </div>
+    </div>
+  )
+
+  const nameAndRole = (
+    <div className="flex flex-col items-start gap-1">
+      <p className="paragraph">{exec.name}</p>
+      {exec.role.title && (
+        <p className="paragraph-xs font-medium text-gray-500">{exec.role.title}</p>
+      )}
+    </div>
+  )
+
+  if (exec.linkedin) {
+    return (
+      <a
+        aria-label={`${exec.name} LinkedIn profile`}
+        className="group flex w-fit flex-col items-start gap-1 rounded-md p-2 transition-colors duration-300 hover:bg-gray-600-opaque md:gap-2 md:p-3"
+        href={exec.linkedin}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {photoSquare}
+        {nameAndRole}
+      </a>
+    )
+  }
+
+  return (
+    <div className="flex w-[6.75rem] flex-col items-start gap-2 md:w-[12.5rem] md:gap-3">
+      {photoSquare}
+      {nameAndRole}
     </div>
   )
 }

--- a/src/components/Generic/ExecCard/ExecCard.tsx
+++ b/src/components/Generic/ExecCard/ExecCard.tsx
@@ -68,7 +68,7 @@ export const ExecCard = ({ exec }: ExecCardProps) => {
   }
 
   return (
-    <div className="flex w-[6.75rem] flex-col items-start gap-2 md:w-[12.5rem] md:gap-3">
+    <div className="flex w-fit flex-col items-start gap-1 p-2 md:gap-2 md:p-3">
       {photoSquare}
       {nameAndRole}
     </div>

--- a/src/mocks/Executive.mock.ts
+++ b/src/mocks/Executive.mock.ts
@@ -26,3 +26,13 @@ export const mockExecutiveWithPhoto: Executive = {
     updatedAt: "2024-05-01T12:00:00Z",
   },
 }
+
+export const mockExecutiveWithLinkedin: Executive = {
+  ...mockExecutiveWithPhoto,
+  linkedin: "https://www.linkedin.com/in/joshua-li",
+}
+
+export const mockExecutiveWithLinkedinFallback: Executive = {
+  ...mockExecutive,
+  linkedin: "https://www.linkedin.com/in/joshua-li",
+}


### PR DESCRIPTION
# Description

Adds LinkedIn linking to exec cards on the `/team` page. When an exec has a LinkedIn URL set in Payload, their whole card (photo + name + role) becomes a link. Hovering shows a subtle gray background tint.

Also added Storybook stories for the two new states (with photo + LinkedIn, and fallback initials + LinkedIn).

Closes #136

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="477" height="491" alt="Screenshot 2026-02-27 at 01 39 08" src="https://github.com/user-attachments/assets/ea59fbd1-bd33-4485-b96c-b5147c632f1b" />

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member