### PR TITLE
feat(payload): add Member collection

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,6 +7,7 @@ import { buildConfig } from "payload"
 import sharp from "sharp"
 import { Executive } from "./payload/collections/Executive"
 import { Media } from "./payload/collections/Media"
+import { Member } from "./payload/collections/Member"
 import { Polaroid } from "./payload/collections/Polaroid"
 import { Reel } from "./payload/collections/Reel"
 import { Sponsor } from "./payload/collections/Sponsor"
@@ -24,7 +25,7 @@ export default buildConfig({
       importMapFile: `${path.resolve(dirname)}/app/payload/admin/importMap.js`,
     },
   },
-  collections: [User, Media, Executive, Sponsor, Reel, Polaroid],
+  collections: [User, Media, Member, Executive, Sponsor, Reel, Polaroid],
   globals: [HomePage],
   editor: lexicalEditor(),
   graphQL: {

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -1,0 +1,132 @@
+import type { CollectionConfig } from "payload"
+
+export const Member: CollectionConfig = {
+  slug: "member",
+  access: {
+    read: () => true,
+  },
+  admin: {
+    useAsTitle: "email",
+  },
+  fields: [
+    {
+      name: "firstName",
+      type: "text",
+      required: true,
+      admin: {
+        description: "First name of the member",
+      },
+    },
+    {
+      name: "lastName",
+      type: "text",
+      required: true,
+      admin: {
+        description: "Last name of the member",
+      },
+    },
+    {
+      name: "upi",
+      type: "text",
+      required: true,
+      unique: true,
+      admin: {
+        description: "University UPI of the member",
+      },
+    },
+    {
+      name: "email",
+      type: "email",
+      required: true,
+      unique: true,
+      admin: {
+        description: "Email address of the member, either uni or personal",
+      },
+    },
+    {
+      name: "uoaID",
+      type: "text",
+      required: true,
+      unique: true,
+      admin: {
+        description: "University of Auckland student ID number",
+      },
+    },
+    {
+      name: "gender",
+      type: "text",
+      required: true,
+      admin: {
+        description: "Gender of the member",
+      },
+    },
+    {
+      name: "phoneNumber",
+      type: "text",
+      required: false,
+      admin: {
+        description: "Phone number of the member",
+      },
+    },
+    {
+      name: "otherMajors",
+      type: "array",
+      required: false,
+      fields: [
+        {
+          name: "major",
+          type: "text",
+        },
+      ],
+      admin: {
+        description: "Other majors the member is studying, if any",
+      },
+    },
+    {
+      name: "studyYear",
+      type: "select",
+      options: [
+        {
+          label: "First Year",
+          value: "first-year",
+        },
+        {
+          label: "Second Year",
+          value: "second-year",
+        },
+        {
+          label: "Third Year",
+          value: "third-year",
+        },
+        {
+          label: "Fourth Year",
+          value: "fourth-year",
+        },
+        {
+          label: "Fifth Year or Above",
+          value: "fifth-year-or-above",
+        },
+      ],
+      required: true,
+      admin: {
+        description: "Current year of study at university",
+      },
+    },
+    {
+      name: "heardAboutUs",
+      type: "text",
+      required: true,
+      admin: {
+        description: "How the member heard about UOACS",
+      },
+    },
+    {
+      name: "eventWishList",
+      type: "text",
+      required: false,
+      admin: {
+        description: "What kinds of events the member would like to see in the future",
+      },
+    },
+  ],
+}

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -70,14 +70,9 @@ export const Member: CollectionConfig = {
     },
     {
       name: "otherMajors",
-      type: "array",
+      type: "text",
+      hasMany: true,
       required: false,
-      fields: [
-        {
-          name: "major",
-          type: "text",
-        },
-      ],
       admin: {
         description: "Other majors the member is studying, if any",
       },

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -29,7 +29,6 @@ export const Member: CollectionConfig = {
       name: "upi",
       type: "text",
       required: true,
-      unique: true,
       admin: {
         description: "University UPI of the member",
       },
@@ -47,7 +46,6 @@ export const Member: CollectionConfig = {
       name: "uoaID",
       type: "text",
       required: true,
-      unique: true,
       admin: {
         description: "University of Auckland student ID number",
       },

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     user: User;
     media: Media;
+    member: Member;
     executive: Executive;
     sponsor: Sponsor;
     reel: Reel;
@@ -82,6 +83,7 @@ export interface Config {
   collectionsSelect: {
     user: UserSelect<false> | UserSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    member: MemberSelect<false> | MemberSelect<true>;
     executive: ExecutiveSelect<false> | ExecutiveSelect<true>;
     sponsor: SponsorSelect<false> | SponsorSelect<true>;
     reel: ReelSelect<false> | ReelSelect<true>;
@@ -170,6 +172,61 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "member".
+ */
+export interface Member {
+  id: string;
+  /**
+   * First name of the member
+   */
+  firstName: string;
+  /**
+   * Last name of the member
+   */
+  lastName: string;
+  /**
+   * University UPI of the member
+   */
+  upi: string;
+  /**
+   * Email address of the member, either uni or personal
+   */
+  email: string;
+  /**
+   * University of Auckland student ID number
+   */
+  uoaID: string;
+  /**
+   * Gender of the member
+   */
+  gender: string;
+  /**
+   * Phone number of the member
+   */
+  phoneNumber?: string | null;
+  otherMajors?:
+    | {
+        major?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Current year of study at university
+   */
+  studyYear: 'first-year' | 'second-year' | 'third-year' | 'fourth-year' | 'fifth-year-or-above';
+  /**
+   * How the member heard about UOACS
+   */
+  heardAboutUs: string;
+  /**
+   * If they were a programming language, this is what they would be
+   */
+  codingLanguage?: string | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -302,6 +359,10 @@ export interface PayloadLockedDocument {
         value: string | Media;
       } | null)
     | ({
+        relationTo: 'member';
+        value: string | Member;
+      } | null)
+    | ({
         relationTo: 'executive';
         value: string | Executive;
       } | null)
@@ -399,6 +460,30 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "member_select".
+ */
+export interface MemberSelect<T extends boolean = true> {
+  firstName?: T;
+  lastName?: T;
+  upi?: T;
+  email?: T;
+  uoaID?: T;
+  gender?: T;
+  phoneNumber?: T;
+  otherMajors?:
+    | T
+    | {
+        major?: T;
+        id?: T;
+      };
+  studyYear?: T;
+  heardAboutUs?: T;
+  codingLanguage?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -207,12 +207,10 @@ export interface Member {
    * Phone number of the member
    */
   phoneNumber?: string | null;
-  otherMajors?:
-    | {
-        major?: string | null;
-        id?: string | null;
-      }[]
-    | null;
+  /**
+   * Other majors the member is studying, if any
+   */
+  otherMajors?: string[] | null;
   /**
    * Current year of study at university
    */
@@ -222,9 +220,9 @@ export interface Member {
    */
   heardAboutUs: string;
   /**
-   * If they were a programming language, this is what they would be
+   * What kinds of events the member would like to see in the future
    */
-  codingLanguage?: string | null;
+  eventWishList?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -473,15 +471,10 @@ export interface MemberSelect<T extends boolean = true> {
   uoaID?: T;
   gender?: T;
   phoneNumber?: T;
-  otherMajors?:
-    | T
-    | {
-        major?: T;
-        id?: T;
-      };
+  otherMajors?: T;
   studyYear?: T;
   heardAboutUs?: T;
-  codingLanguage?: T;
+  eventWishList?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
> [!WARNING]
> This PR is a part of a stack
>
> Please review and merge in the following order, (from top to bottom):
> - [ ] #160  (This PR)
> - [ ] #158 
> - [ ] #159 
> - [ ] #161
> - [ ] #163
> - [ ] #164
> - [ ] #165
> - [ ] #166

# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

 - Adds a new `Member` Payload collection to store sign-up data for UOACS members
  - Defines fields for personal info (name, email, UPI, UoA ID), demographics (gender, phone), academic details (study year, other majors), and engagement data (how they heard about us, event wishlist)
  - Registers the collection in `payload.config.ts` and regenerates `payload-types.ts`

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
