### PR TITLE
fix: remove -z-1 causing noninteractive reels

### DIFF
--- a/src/components/Composite/AboutUsSection/AboutUsSection.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.tsx
@@ -51,7 +51,7 @@ export const AboutUsSection = ({ reels }: AboutUsSectionProps) => {
           <p className="paragraph-sm font-medium">Membership is 100% free so come join us!</p>
         </div>
       </div>
-      <div className="-z-1 hidden flex-none md:flex">
+      <div className="hidden flex-none md:flex">
         <div className="flex h-full flex-row flex-nowrap justify-start gap-4 overflow-x-visible">
           {reels.map((reel) => (
             <Reel key={reel.id} reel={reel} />


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

Removed a `-z-1` which caused the reels to no longer be interactive. (this is from when we needed tabby behind the reels i think)

This will bring back the instagram link, and expandable/contractable
 
## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
