### PR TITLE
fix(media): bring back public read access to media

### DIFF
--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from "payload"
 
 export const Media: CollectionConfig = {
   slug: "media",
+  access: {
+    read: () => true,
+  },
   fields: [
     {
       name: "alt",


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

In #170 i accidentally revoked public access to media, meaning that all <Image> tags etc that use the public rest api rather than a local api, were failing to fetch as they didnt have permission. This PR reverts the change in the `Media` collection.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
