### PR TITLE
fix(navbar): hide socials at in-between breakpoints

### DIFF
--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -78,7 +78,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          <Link href="/sign-up">
+          <Link className="hidden lg:block" href="/sign-up">
             <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Join UOACS
             </Button>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -62,7 +62,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
           </Link>
         </motion.div>
         <MobileNavbar links={links} socialLinks={socialLinks} />
-        <div className="nowrap hidden flex-row gap-5 md:flex">
+        <div className="nowrap hidden flex-row md:flex lg:gap-5">
           <div className="flex flex-row items-center gap-5">
             {links
               .filter((link) => link.label.toLowerCase() !== "home")
@@ -75,10 +75,11 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               label="Socials"
               options={dropdownOptions}
               theme="primary"
+              triggerClassName="hidden lg:flex"
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          <Link className="hidden lg:block" href="/sign-up">
+          <Link href="/sign-up">
             <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Join UOACS
             </Button>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes an issue introduced in #161 where the join us button no longer hid itself and caused the navbar to "squish".
I have decided to actually keep the join us button visible and hide the socials dropdown since when the navbar is visible, so are the social links in the `HeroSection`, whereas the join us in the `AboutUsSection` is not.

<img width="798" height="151" alt="Screenshot 2026-03-01 at 12 46 14" src="https://github.com/user-attachments/assets/b0574ff2-3d5b-419b-abbb-467e000bc80e" />

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<img width="798" height="151" alt="Screenshot 2026-03-01 at 12 46 26" src="https://github.com/user-attachments/assets/35daca7f-0137-40da-9abe-4c16c8cebbf0" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
