### PR TITLE
feat: add `/privacy` page with privacy policy

### DIFF
--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next"
+import { getPayload } from "payload"
+import { Heading } from "@/components/Primitive"
+import config from "@/payload.config"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "How the University of Auckland Computer Society collects and uses your data.",
+}
+
+type PrivacySection = {
+  heading: string
+  content: string
+}
+
+type PrivacyPolicyGlobal = {
+  sections?: PrivacySection[] | null
+  updatedAt?: string | null
+}
+
+export default async function PrivacyPage() {
+  const payloadConfig = await config
+  const payload = await getPayload({ config: payloadConfig })
+
+  const policy = (await payload.findGlobal({ slug: "privacy-policy" })) as PrivacyPolicyGlobal
+
+  const sections = policy.sections ?? []
+  const updatedAt = policy.updatedAt ? new Date(policy.updatedAt) : null
+
+  return (
+    <div className="flex w-full flex-col items-center gap-8 px-4">
+      <div className="flex w-full flex-col gap-2">
+        <Heading className="justify-start" h={2} period>
+          Privacy Policy
+        </Heading>
+        {updatedAt && (
+          <p className="paragraph-xs text-gray-500">
+            Last updated:{" "}
+            {updatedAt.toLocaleDateString("en-NZ", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+        )}
+      </div>
+
+      <div className="flex w-full flex-col gap-8">
+        {sections.length === 0 ? (
+          <p className="paragraph text-gray-500">Privacy policy coming soon.</p>
+        ) : (
+          sections.map((section, i) => (
+            <div className="flex flex-col gap-2" key={`${section.heading}-${i}`}>
+              <h3 className="paragraph font-semibold">{section.heading}</h3>
+              <p className="paragraph whitespace-pre-line text-gray-700">{section.content}</p>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = {
 }
 
 type PrivacySection = {
+  id: string
   heading: string
   content: string
 }
@@ -49,8 +50,8 @@ export default async function PrivacyPage() {
         {sections.length === 0 ? (
           <p className="paragraph text-gray-500">Privacy policy coming soon.</p>
         ) : (
-          sections.map((section, i) => (
-            <div className="flex flex-col gap-2" key={`${section.heading}-${i}`}>
+          sections.map((section) => (
+            <div className="flex flex-col gap-2" key={section.id}>
               <h3 className="paragraph font-semibold">{section.heading}</h3>
               <p className="paragraph whitespace-pre-line text-gray-700">{section.content}</p>
             </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -25,5 +25,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/sign-up`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      priority: 0.5,
+    },
   ]
 }

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -52,7 +52,15 @@ export const Footer = ({ links, socialLinks }: FooterProps) => {
       <NavbarGradient className="h-full translate-y-2/3 md:h-full md:translate-y-5/6" />
       <div className="flex flex-col gap-4">
         <div className="flex flex-row flex-wrap items-start justify-between gap-2">
-          <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>
+          <div className="flex flex-col gap-1">
+            <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>
+            <Link
+              className="paragraph-xs w-fit text-gray-400 transition-colors hover:text-white"
+              href="/privacy"
+            >
+              Privacy Policy
+            </Link>
+          </div>
           <InterestedButton className="md:hidden" />
         </div>
         <nav aria-label="Social media links" className="flex flex-row items-start gap-4">

--- a/src/components/Composite/SignUpForm/SignUpForm.tsx
+++ b/src/components/Composite/SignUpForm/SignUpForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { Controller, useForm } from "react-hook-form"
@@ -190,6 +191,14 @@ export const SignUpForm = () => {
         label="What kinds of events would you like to see us host?"
         type="text"
       />
+
+      <p className="paragraph-xs text-gray-500">
+        By signing up, you agree to our{" "}
+        <Link className="underline transition-colors hover:text-gray-700" href="/privacy">
+          Privacy Policy
+        </Link>
+        .
+      </p>
 
       <Button disabled={loading} theme="dark" type="submit">
         {loading ? "Submitting..." : "Sign Up"}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -2,6 +2,7 @@ export const Routes = {
   home: "/",
   team: "/team",
   sponsors: "/sponsors",
+  privacy: "/privacy",
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,7 @@ import { Reel } from "./payload/collections/Reel"
 import { Sponsor } from "./payload/collections/Sponsor"
 import { User } from "./payload/collections/User"
 import { HomePage } from "./payload/globals/HomePage"
+import { PrivacyPolicy } from "./payload/globals/PrivacyPolicy"
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -26,7 +27,7 @@ export default buildConfig({
     },
   },
   collections: [User, Media, Member, Executive, Sponsor, Reel, Polaroid],
-  globals: [HomePage],
+  globals: [HomePage, PrivacyPolicy],
   editor: lexicalEditor(),
   graphQL: {
     disable: true,

--- a/src/payload/globals/PrivacyPolicy.ts
+++ b/src/payload/globals/PrivacyPolicy.ts
@@ -1,0 +1,28 @@
+import type { GlobalConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
+
+const { globalAfterChange } = makeRevalidateHooks([Routes.privacy])
+
+export const PrivacyPolicy: GlobalConfig = {
+  slug: "privacy-policy",
+  fields: [
+    {
+      name: "sections",
+      type: "array",
+      fields: [
+        {
+          name: "heading",
+          type: "text",
+          required: true,
+        },
+        {
+          name: "content",
+          type: "textarea",
+          required: true,
+        },
+      ],
+    },
+  ],
+  hooks: { afterChange: [globalAfterChange] },
+}

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -99,9 +99,11 @@ export interface Config {
   fallbackLocale: null;
   globals: {
     'home-page': HomePage;
+    'privacy-policy': PrivacyPolicy;
   };
   globalsSelect: {
     'home-page': HomePageSelect<false> | HomePageSelect<true>;
+    'privacy-policy': PrivacyPolicySelect<false> | PrivacyPolicySelect<true>;
   };
   locale: null;
   user: User;
@@ -582,11 +584,43 @@ export interface HomePage {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "privacy-policy".
+ */
+export interface PrivacyPolicy {
+  id: string;
+  sections?:
+    | {
+        heading: string;
+        content: string;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "home-page_select".
  */
 export interface HomePageSelect<T extends boolean = true> {
   reels?: T;
   polaroids?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "privacy-policy_select".
+ */
+export interface PrivacyPolicySelect<T extends boolean = true> {
+  sections?:
+    | T
+    | {
+        heading?: T;
+        content?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR adds a CMS-driven /privacy page to surface UOACS's privacy policy under the NZ Privacy Act 2020.

- adds the PrivacyPolicy Payload global (privacy-policy slug) with a sections array — each section has a heading text field and a content textarea — so exec admins can manage the policy without touching code
- adds /privacy to Routes and registers the global in payload.config.ts alongside HomePage
- adds the /privacy server component that fetches the global, renders a Heading h={2} period title, displays the auto-generated updatedAt as "Last updated: …", and maps sections to subheading + body; falls back to "Privacy policy coming soon." if no sections exist
- adds a "Privacy Policy" link in the footer below the copyright text
- adds a "By signing up, you agree to our Privacy Policy." disclaimer above the submit button in SignUpForm
- adds /privacy (priority 0.5) and /sign-up (priority 0.8) to sitemap.ts

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
