### PR TITLE
fix(team): make heading size consistent and make gaps smaller

### DIFF
--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -88,85 +88,91 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
 
   return (
     <>
-      <div className="flex flex-col items-center gap-2 px-4 text-center">
-        <Heading h={1} period>
-          Our Team
-        </Heading>
-        <p className="paragraph text-gray-700">These are the people who make this club possible.</p>
-      </div>
-      <div className="flex w-full flex-col items-center justify-center gap-12">
-        <div className="hidden max-w-200 flex-row flex-wrap items-center justify-center gap-4 md:flex">
-          {currentTeams.map((team: string) => (
-            <BorderButton
-              aria-pressed={selectedTeam === team}
-              key={team}
-              onClick={() => handleTeamSelect(team)}
-              variant={{
-                theme: selectedTeam === team ? "primary" : "light",
-                size: "sm-wide",
-                border: selectedTeam === team,
-              }}
-            >
-              {`${team.toUpperCase()} [${
-                currentExecs.filter((exec: Executive) =>
-                  (exec.role?.teams ?? []).includes(toTeam(team)),
-                ).length
-              }]`}
-            </BorderButton>
-          ))}
-        </div>
-        <div className="grid w-full grid-cols-[repeat(auto-fit,128px)] justify-center gap-2 md:grid-cols-[repeat(auto-fit,200px)] md:gap-6">
-          {currentExecs
-            ?.filter((exec: Executive) =>
-              selectedTeam ? (exec.role?.teams ?? []).includes(toTeam(selectedTeam)) : true,
-            )
-            .map((exec: Executive) => (
-              <ExecCard exec={exec} key={exec.id} />
-            ))}
-        </div>
-      </div>
-      <div className="flex flex-col items-center gap-2 px-4 text-center">
-        <div className="relative">
+      <div className="flex w-full flex-col items-center gap-14 md:gap-18">
+        <div className="flex flex-col items-center gap-2 px-4 text-center">
           <Heading h={1} period>
-            Past Executives
+            Our Team
           </Heading>
+          <p className="paragraph text-gray-700">
+            These are the people who make this club possible.
+          </p>
         </div>
-        <p className="paragraph text-gray-700">UOACS Alumni</p>
+        <div className="flex w-full flex-col items-center justify-center gap-12">
+          <div className="hidden max-w-200 flex-row flex-wrap items-center justify-center gap-4 md:flex">
+            {currentTeams.map((team: string) => (
+              <BorderButton
+                aria-pressed={selectedTeam === team}
+                key={team}
+                onClick={() => handleTeamSelect(team)}
+                variant={{
+                  theme: selectedTeam === team ? "primary" : "light",
+                  size: "sm-wide",
+                  border: selectedTeam === team,
+                }}
+              >
+                {`${team.toUpperCase()} [${
+                  currentExecs.filter((exec: Executive) =>
+                    (exec.role?.teams ?? []).includes(toTeam(team)),
+                  ).length
+                }]`}
+              </BorderButton>
+            ))}
+          </div>
+          <div className="grid w-full grid-cols-[repeat(auto-fit,128px)] justify-center gap-2 md:grid-cols-[repeat(auto-fit,200px)] md:gap-6">
+            {currentExecs
+              ?.filter((exec: Executive) =>
+                selectedTeam ? (exec.role?.teams ?? []).includes(toTeam(selectedTeam)) : true,
+              )
+              .map((exec: Executive) => (
+                <ExecCard exec={exec} key={exec.id} />
+              ))}
+          </div>
+        </div>
       </div>
-      <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-[4.5rem]">
-        {pastTeams.map((team: string) => {
-          const execsInTeam = pastExecs.filter((exec: Executive) =>
-            (exec.role?.teams ?? []).includes(toTeam(team)),
-          )
-          return (
-            <Container
-              className="flex w-full flex-col gap-0 px-3 py-6 md:gap-2.5"
-              key={team}
-              theme="primary"
-              title={TEAM_DISPLAY_NAMES[team]}
-            >
-              {execsInTeam.map((exec: Executive) =>
-                exec.linkedin ? (
-                  <Link
-                    className="flex w-full flex-row items-center justify-between rounded-sm px-3 py-1.5 font-inter transition-all duration-300 hover:bg-gray-600-opaque md:max-w-90"
-                    href={exec.linkedin}
-                    key={exec.id}
-                  >
-                    <p className="heading-4 font-normal">{exec.name}</p>
-                    {exec.linkedin && <SocialIcon.LinkedIn className="h-7 w-7 md:h-8 md:w-8" />}
-                  </Link>
-                ) : (
-                  <p
-                    className="heading-4 w-full p-2 px-3 py-1.5 font-normal md:max-w-90"
-                    key={exec.id}
-                  >
-                    {exec.name}
-                  </p>
-                ),
-              )}
-            </Container>
-          )
-        })}
+      <div className="flex w-full flex-col items-center gap-14 md:gap-18">
+        <div className="flex flex-col items-center gap-2 px-4 text-center">
+          <div className="relative">
+            <Heading h={1} period>
+              Past Executives
+            </Heading>
+          </div>
+          <p className="paragraph text-gray-700">UOACS Alumni</p>
+        </div>
+        <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-[4.5rem]">
+          {pastTeams.map((team: string) => {
+            const execsInTeam = pastExecs.filter((exec: Executive) =>
+              (exec.role?.teams ?? []).includes(toTeam(team)),
+            )
+            return (
+              <Container
+                className="flex w-full flex-col gap-0 px-3 py-6 md:gap-2.5"
+                key={team}
+                theme="primary"
+                title={TEAM_DISPLAY_NAMES[team]}
+              >
+                {execsInTeam.map((exec: Executive) =>
+                  exec.linkedin ? (
+                    <Link
+                      className="flex w-full flex-row items-center justify-between rounded-sm px-3 py-1.5 font-inter transition-all duration-300 hover:bg-gray-600-opaque md:max-w-90"
+                      href={exec.linkedin}
+                      key={exec.id}
+                    >
+                      <p className="heading-4 font-normal">{exec.name}</p>
+                      {exec.linkedin && <SocialIcon.LinkedIn className="h-7 w-7 md:h-8 md:w-8" />}
+                    </Link>
+                  ) : (
+                    <p
+                      className="heading-4 w-full p-2 px-3 py-1.5 font-normal md:max-w-90"
+                      key={exec.id}
+                    >
+                      {exec.name}
+                    </p>
+                  ),
+                )}
+              </Container>
+            )
+          })}
+        </div>
       </div>
     </>
   )

--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -89,7 +89,7 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
   return (
     <>
       <div className="flex flex-col items-center gap-2 px-4 text-center">
-        <Heading h={2} period>
+        <Heading h={1} period>
           Our Team
         </Heading>
         <p className="paragraph text-gray-700">These are the people who make this club possible.</p>
@@ -127,7 +127,7 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
       </div>
       <div className="flex flex-col items-center gap-2 px-4 text-center">
         <div className="relative">
-          <Heading h={2} period>
+          <Heading h={1} period>
             Past Executives
           </Heading>
         </div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR fixes heading consistency on the team page by upgrading headings to h1 and adjusting spacing to match the rest of the site.
  - updates "Our Team" and "Past Executives" headings from h={2} to h={1} to match the correct heading size on sponsors
  - wraps each section in a flex flex-col container with gap-14 md:gap-18 to create consistent and smaller spacing between the heading and content

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
