### PR TITLE
refactor: centralise payload initialisation into shared module

### DIFF
--- a/src/app/(frontend)/_components/SponsorsServerSection.tsx
+++ b/src/app/(frontend)/_components/SponsorsServerSection.tsx
@@ -1,12 +1,8 @@
-import { getPayload } from "payload"
 import { SponsorsSection } from "@/components/Composite"
+import { payload } from "@/lib/payload"
 import type { Sponsor } from "@/payload/payload-types"
-import config from "@/payload.config"
 
 export const SponsorsServerSection = async () => {
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
-
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
     collection: "sponsor",
   })

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,7 +1,6 @@
-import config from "@payload-config"
 import type { Metadata } from "next"
-import { getPayload } from "payload"
 import { AboutUsSection, HeroSection, ValuesSection, WhoWeAreSection } from "@/components/Composite"
+import { payload } from "@/lib/payload"
 import type { Reel } from "@/payload/payload-types"
 import { SponsorsServerSection } from "./_components/SponsorsServerSection"
 
@@ -11,9 +10,6 @@ export const metadata: Metadata = {
 }
 
 export default async function HomePage() {
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
-
   const homePage = await payload.findGlobal({
     slug: "home-page",
   })

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
-import { getPayload } from "payload"
 import { Heading } from "@/components/Primitive"
-import config from "@/payload.config"
+import { payload } from "@/lib/payload"
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -20,9 +19,6 @@ type PrivacyPolicyGlobal = {
 }
 
 export default async function PrivacyPage() {
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
-
   const policy = (await payload.findGlobal({ slug: "privacy-policy" })) as PrivacyPolicyGlobal
 
   const sections = policy.sections ?? []

--- a/src/app/(frontend)/sponsors/page.tsx
+++ b/src/app/(frontend)/sponsors/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next"
-import { getPayload } from "payload"
 import { Container, Heading, LazyImage } from "@/components/Primitive"
+import { payload } from "@/lib/payload"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
-import config from "@/payload.config"
 import { SPONSOR_TIER_ORDER, SponsorTier } from "@/types/enums"
 
 export const metadata: Metadata = {
@@ -13,9 +12,6 @@ export const metadata: Metadata = {
 }
 
 export default async function SponsorsPage() {
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
-
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
     collection: "sponsor",
     depth: 2,

--- a/src/app/(frontend)/team/page.tsx
+++ b/src/app/(frontend)/team/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
-import { getPayload } from "payload"
+import { payload } from "@/lib/payload"
 import type { Executive } from "@/payload/payload-types"
-import config from "@/payload.config"
 import { TeamPageClient } from "./_components/TeamPageClient"
 
 export const metadata: Metadata = {
@@ -10,9 +9,6 @@ export const metadata: Metadata = {
 }
 
 export default async function TeamPage() {
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
-
   const execs: { docs: Executive[] } = await payload.find({
     collection: "executive",
     limit: 100,

--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -1,11 +1,9 @@
-import { getPayload, ValidationError } from "payload"
-import payloadConfig from "@/payload.config"
+import { ValidationError } from "payload"
+import { payload } from "@/lib/payload"
 import { createMemberSchema } from "@/types/schemas/member"
 
 export async function POST(request: Request) {
   const member = createMemberSchema.parse(await request.json())
-
-  const payload = await getPayload({ config: payloadConfig })
 
   try {
     const createdMember = await payload.create({

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,0 +1,4 @@
+import config from "@payload-config"
+import { getPayload, type Payload } from "payload"
+
+export const payload: Payload = await getPayload({ config })


### PR DESCRIPTION
# Description
This PR centralises the Payload CMS initialisation into a shared module at `src/lib/payload.ts`, removing the repeated `await getPayload({ config: payloadConfig })` boilerplate across pages and API routes.

- introduces `src/lib/payload.ts` which exports a single shared `payload` instance
- updates `src/app/(frontend)/page.tsx`, `SponsorsServerSection.tsx`, `sponsors/page.tsx`, `team/page.tsx`, `privacy/page.tsx`, and `api/sign-up/route.ts` to import `payload` from `@/lib/payload` instead of initialising inline

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
