### PR TITLE
feat: add renovate workflow via daily cron schedule

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,74 @@
+name: Renovate
+on:
+  workflow_dispatch:
+    inputs:
+      repoCache:
+        description: 'Reset or disable the cache?'
+        type: choice
+        default: enabled
+        options:
+          - enabled
+          - disabled
+          - reset
+  schedule:
+    - cron: '0 3 * * *'
+
+env:
+  cache_archive: renovate_cache.tar.gz
+  cache_dir: /tmp/renovate/cache/renovate/repository
+  cache_key: renovate-cache
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download renovate cache
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        continue-on-error: true
+        with:
+          name: ${{ env.cache_key }}
+          path: cache-download
+
+      - name: Extract renovate cache
+        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        run: |
+          set -x
+          # Skip if no cache is set, such as the first time it runs.
+          if [ ! -d cache-download ] ; then
+            echo "No cache found."
+            exit 0
+          fi
+          mkdir -p $cache_dir
+          tar -xzf cache-download/$cache_archive -C $cache_dir
+          sudo chown -R 12021:0 /tmp/renovate/
+          ls -R $cache_dir
+
+      - name: Run renovate
+        uses: renovatebot/github-action@v46.1.3
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          renovate-version: 46.1.3
+        env:
+          RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
+
+      - name: Compress renovate cache
+        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        run: |
+          ls $cache_dir
+          tar -czvf $cache_archive -C $cache_dir .
+
+      - name: Upload renovate cache
+        uses: actions/upload-artifact@v4
+        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        with:
+          name: ${{ env.cache_key }}
+          path: ${{ env.cache_archive }}
+          retention-days: 1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies", "renovate-bot"],
+  "timezone": "Pacific/Auckland",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
+  "commitMessagePrefix": "chore(deps):",
+  "dependencyDashboard": true,
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "description": "Group Payload CMS related dependencies",
+      "groupName": "Payload CMS",
+      "matchPackageNames": ["payload", "@payloadcms/**"]
+    },
+    {
+      "description": "Group React related dependencies",
+      "groupName": "React",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+    },
+    {
+      "description": "Group Storybook related dependencies",
+      "groupName": "Storybook",
+      "matchPackageNames": ["storybook", "@storybook/**", "@chromatic-com/storybook"]
+    },
+    {
+      "description": "Group Vitest related dependencies",
+      "groupName": "Vitest",
+      "matchPackageNames": ["vitest", "@vitest/**"]
+    },
+    {
+      "description": "TypeScript type definitions",
+      "groupName": "TypeScript types",
+      "matchPackagePatterns": ["^@types/"],
+      "excludePackageNames": ["@types/react", "@types/react-dom"]
+    },
+    {
+      "description": "Node.js version",
+      "groupName": "Node.js",
+      "matchPackageNames": ["node"]
+    },
+    {
+      "description": "pnpm version",
+      "groupName": "pnpm",
+      "matchPackageNames": ["pnpm"]
+    }
+  ],
+  "vulnerabilityAlerts": { "labels": ["security"], "automerge": false }
+}


### PR DESCRIPTION
 # Description

This PR sets up Renovate for automated dependency management, introducing a `renovate.json` config and a GitHub Actions workflow to run it on a daily cron schedule.

- adds `renovate.json` with `config:recommended` base, configured with NZ timezone, PR rate limits (`prHourlyLimit: 2`, `prConcurrentLimit: 10`), and grouped package rules for Payload CMS, React, Storybook, Vitest, TypeScript types, Node.js, and pnpm
- adds `.github/workflows/renovate.yaml` that runs daily at 3am UTC via cron, with support for manual dispatch and a cache mechanism to speed up subsequent runs
- enables vulnerability alerts with the `security` label (no automerge)

Closes #185 

> [!NOTE]
> Note that the `RENOVATE_TOKEN` secret needs to be set in the repository settings before the workflow will run successfully.
> - [x] `RENOVATE_TOKEN` has been added to the repo settings

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
