### PR TITLE
fix(renovate): set gitAuthor and target repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "gitAuthor": "renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
   "labels": ["dependencies", "renovate-bot"],
   "timezone": "Pacific/Auckland",
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Summary

- Fixes the `WARN: No repositories found` error by passing `RENOVATE_REPOSITORIES: ${{ github.repository }}` as a step-level env var in the Renovate workflow
- Fixes the `gitAuthor` warning by setting the official `renovate[bot]` GitHub App identity in `renovate.json`, preventing commits being attributed to the Mend-owned `renovate@whitesourcesoftware.com` address

## Test plan

- [ ] Trigger the Renovate workflow manually via `workflow_dispatch` and confirm no "No repositories found" warning
- [ ] Confirm commits created by Renovate are attributed to `renovate[bot]` without the "Unverified" signature warning