### PR TITLE
feat(sponsors-section): replace ticker with static sponsors when 2 or less

### DIFF
--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -2,9 +2,9 @@ import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { SponsorTicker } from "@/components/Generic"
 import { Button, Heading, LazyImage } from "@/components/Primitive"
+import { TIER_SIZES } from "@/lib/constants"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
-import { SponsorTier } from "@/types/enums"
 
 /**
  * Props for the {@link SponsorsSection} component
@@ -54,14 +54,6 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
       ) : (
         <div className="flex flex-col items-center justify-center gap-4 md:flex-row">
           {sponsors.map((sponsor) => {
-            const tierSizes: Record<SponsorTier, { height: number; width: number }> = {
-              [SponsorTier.DIAMOND]: {
-                height: 120,
-                width: 320,
-              },
-              [SponsorTier.GOLD]: { height: 120, width: 320 },
-              [SponsorTier.SILVER]: { height: 80, width: 240 },
-            }
             const photo = sponsor.logo
             let src: string | undefined
 
@@ -81,9 +73,9 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
                 <LazyImage
                   alt={sponsor.name || "Sponsor Logo"}
                   className="max-h-full max-w-full object-contain"
-                  height={tierSizes[sponsor.tier]?.height}
+                  height={TIER_SIZES[sponsor.tier]?.height}
                   src={src}
-                  width={tierSizes[sponsor.tier]?.width}
+                  width={TIER_SIZES[sponsor.tier]?.width}
                 />
               </Link>
             )

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -1,9 +1,10 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { SponsorTicker } from "@/components/Generic"
-import { Button, Heading } from "@/components/Primitive"
+import { Button, Heading, LazyImage } from "@/components/Primitive"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
+import { SponsorTier } from "@/types/enums"
 
 /**
  * Props for the {@link SponsorsSection} component
@@ -39,7 +40,7 @@ const ColourPalette = ({ className }: { className: string }) => {
 export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
   return (
     <div className="flex max-w-360 flex-col items-center justify-center gap-6 overflow-hidden md:gap-12">
-      <div className="relative flex flex-col items-center gap-6 px-4 py-12 text-center md:py-12">
+      <div className="relative flex flex-col items-center gap-6 px-4 pt-12 pb-6 text-center md:py-12">
         <ColourPalette className="top-0 right-0" />
         <Heading h={2}>Sponsored By</Heading>
         <p className="paragraph">
@@ -48,7 +49,47 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
         </p>
         <ColourPalette className="bottom-0 left-0 hidden md:grid" />
       </div>
-      <SponsorTicker containerClassName="max-w-360" items={sponsors} />
+      {sponsors.length > 2 ? (
+        <SponsorTicker containerClassName="max-w-360" items={sponsors} />
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-4 md:flex-row">
+          {sponsors.map((sponsor) => {
+            const tierSizes: Record<SponsorTier, { height: number; width: number }> = {
+              [SponsorTier.DIAMOND]: {
+                height: 120,
+                width: 320,
+              },
+              [SponsorTier.GOLD]: { height: 120, width: 320 },
+              [SponsorTier.SILVER]: { height: 80, width: 240 },
+            }
+            const photo = sponsor.logo
+            let src: string | undefined
+
+            if (!photo) {
+              src = undefined
+            } else if (typeof photo === "string") {
+              src = photo
+            } else if (typeof photo === "object" && photo !== null) {
+              const maybeMedia = photo as { url?: string | null; thumbnailURL?: string | null }
+              src = maybeMedia.url ?? maybeMedia.thumbnailURL ?? undefined
+            }
+
+            if (!src) return null
+
+            return (
+              <Link href="/sponsors" key={sponsor.id}>
+                <LazyImage
+                  alt={sponsor.name || "Sponsor Logo"}
+                  className="max-h-full max-w-full object-contain"
+                  height={tierSizes[sponsor.tier]?.height}
+                  src={src}
+                  width={tierSizes[sponsor.tier]?.width}
+                />
+              </Link>
+            )
+          })}
+        </div>
+      )}
       <Link href="/sponsors">
         <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
           See All Our Sponsors

--- a/src/components/Generic/SponsorTicker/SponsorTicker.tsx
+++ b/src/components/Generic/SponsorTicker/SponsorTicker.tsx
@@ -3,9 +3,10 @@
 import Link from "next/link"
 import { SmartTicker } from "react-smart-ticker"
 import { LazyImage } from "@/components/Primitive"
+import { TIER_SIZES } from "@/lib/constants"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
-import { SponsorTier } from "@/types/enums"
+import type { SponsorTier } from "@/types/enums"
 
 /**
  * Props for the SponsorTicker component
@@ -29,15 +30,6 @@ export interface SponsorTickerProps {
  * @returns a sponsor ticker component
  */
 export const SponsorTicker = ({ items, containerClassName }: SponsorTickerProps) => {
-  const tierSizes: Record<SponsorTier, { height: number; width: number }> = {
-    [SponsorTier.DIAMOND]: {
-      height: 120,
-      width: 320,
-    },
-    [SponsorTier.GOLD]: { height: 120, width: 320 },
-    [SponsorTier.SILVER]: { height: 80, width: 240 },
-  }
-
   // Duplicate items to cover full width of page
   const repeatedItems = [...items, ...items]
 
@@ -73,9 +65,9 @@ export const SponsorTicker = ({ items, containerClassName }: SponsorTickerProps)
               <LazyImage
                 alt={sponsor.name || "Sponsor Logo"}
                 className="max-h-full max-w-full object-contain"
-                height={tierSizes[sponsor.tier as SponsorTier].height}
+                height={TIER_SIZES[sponsor.tier as SponsorTier].height}
                 src={src}
-                width={tierSizes[sponsor.tier as SponsorTier].width}
+                width={TIER_SIZES[sponsor.tier as SponsorTier].width}
               />
             </Link>
           )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,6 @@
 import type { SocialLink } from "@/components/Generic"
 import { SOCIAL_ICONS } from "@/components/Primitive"
+import { SponsorTier } from "@/types/enums"
 
 export const SOCIAL_LINKS: SocialLink[] = [
   { icon: SOCIAL_ICONS.Discord, label: "Discord", href: "https://discord.gg/HsG73WdWFm" },
@@ -19,3 +20,12 @@ export const SOCIAL_LINKS: SocialLink[] = [
     href: "https://www.linkedin.com/company/university-of-auckland-compsci-society/posts/?feedView=all",
   },
 ]
+
+export const TIER_SIZES: Record<SponsorTier, { height: number; width: number }> = {
+  [SponsorTier.DIAMOND]: {
+    height: 120,
+    width: 320,
+  },
+  [SponsorTier.GOLD]: { height: 120, width: 320 },
+  [SponsorTier.SILVER]: { height: 80, width: 240 },
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

Now that we only have 2 sponsors lol, having a ticker imo looks really bad as it’s just repeating the same two over and over, making it more obvious that we dont have many sponsors right now. This PR makes it so that the sponsors are static when there are two or less sponsors.

- <img width="1705" height="766" alt="Screenshot 2026-03-09 at 11 36 41" src="https://github.com/user-attachments/assets/96dee5d4-1cfc-4f15-b4d9-1b55ce176faa" />
  - for example this makes it more obvious in my opinion and looks worse

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="387" height="683" alt="Screenshot 2026-03-09 at 11 33 48" src="https://github.com/user-attachments/assets/b3e36828-1ad1-43c3-bc44-153b05d98a86" />
<img width="1153" height="617" alt="Screenshot 2026-03-09 at 11 34 11" src="https://github.com/user-attachments/assets/97bf33c3-75ce-475d-8d87-b6346071c0b0" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)