### PR TITLE
feat(payload): enable member import via import-export plugin

### DIFF
--- a/src/app/payload/admin/importMap.js
+++ b/src/app/payload/admin/importMap.js
@@ -1,4 +1,5 @@
 import { ExportListMenuItem as ExportListMenuItem_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
+import { ImportListMenuItem as ImportListMenuItem_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { FormatField as FormatField_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { LimitField as LimitField_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { Page as Page_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
@@ -17,6 +18,7 @@ import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 
 export const importMap = {
   "@payloadcms/plugin-import-export/rsc#ExportListMenuItem": ExportListMenuItem_cdf7e044479f899a31f804427d568b36,
+  "@payloadcms/plugin-import-export/rsc#ImportListMenuItem": ImportListMenuItem_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#FormatField": FormatField_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#LimitField": LimitField_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#Page": Page_cdf7e044479f899a31f804427d568b36,

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -71,7 +71,6 @@ export default buildConfig({
           export: {
             disableSave: true,
           },
-          import: false,
         },
       ],
     }),

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -70,6 +70,10 @@ export default buildConfig({
           slug: "member",
           export: {
             disableSave: true,
+            disableJobsQueue: true,
+          },
+          import: {
+            disableJobsQueue: true,
           },
         },
       ],

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -43,6 +43,9 @@ export const Member: CollectionConfig = {
       name: "uoaID",
       type: "text",
       required: true,
+      hooks: {
+        beforeChange: [({ value }) => (typeof value === "number" ? String(value) : value)],
+      },
       admin: {
         description: "University of Auckland student ID number",
       },


### PR DESCRIPTION
This PR enables member import functionality in the Payload CMS admin panel using the `@payloadcms/plugin-import-export` plugin.

- enables the `import` option on the `member` collection in `payload.config.ts`, replacing the previous `import: false` setting
- sets `disableJobsQueue: true` on both `import` and `export` configs to avoid job queue dependency
- registers `ImportListMenuItem` in `importMap.js` so the import UI component is available in the admin panel
- adds a `beforeChange` hook on the `uoaID` field in `Member.ts` to coerce numeric values to strings, preventing type errors during CSV import

## Ticket

Not related to a ticket.

## How to test this change

1. Run the development server with `npm run dev`
2. Navigate to the Payload admin panel at `/admin`
3. Go to the **Members** collection list view
4. Confirm an "Import" button appears in the list menu alongside the existing "Export" button
5. Prepare a CSV file with a `uoaID` column containing numeric values (e.g. `1234567`)
6. Use the import UI to upload the CSV and confirm members are created without type errors on `uoaID`
7. Confirm export still works as before