### PR TITLE
feat(payload): add SocialLinks global with per-platform href fields

### DIFF
--- a/src/app/(frontend)/_components/SponsorsServerSection.tsx
+++ b/src/app/(frontend)/_components/SponsorsServerSection.tsx
@@ -1,10 +1,10 @@
 import { SponsorsSection } from "@/components/Composite"
-import { payload } from "@/lib/payload"
+import { payload, Slugs } from "@/lib/payload"
 import type { Sponsor } from "@/payload/payload-types"
 
 export const SponsorsServerSection = async () => {
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
-    collection: "sponsor",
+    collection: Slugs.Collections.sponsor,
   })
 
   return <SponsorsSection sponsors={sponsors} />

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,7 +4,7 @@ import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
-import { getSocialLinks } from "@/lib/payload"
+import { getSocialLinks } from "@/lib/helpers"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,7 +4,8 @@ import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
-import { SOCIAL_LINKS } from "@/lib/constants"
+import type { SocialLink } from "@/components/Generic"
+import { payload } from "@/lib/payload"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -79,6 +80,16 @@ const navbarLinks: { label: string; href: string }[] = [
 export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 
+  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
+    slug: "social-links",
+  })
+  const socialLinks: SocialLink[] = [
+    { icon: "discord", label: "Discord", href: discordHref ?? "" },
+    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
+    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
+    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
+  ]
+
   return (
     <html
       className={`${inter.variable} ${switzer.variable} ${mono.variable} overflow-x-hidden`}
@@ -87,10 +98,10 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
         <Toaster />
         <div className="mx-auto flex w-full max-w-[1480px] grow flex-col gap-14 px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-          <Navbar links={navbarLinks} socialLinks={SOCIAL_LINKS} />
+          <Navbar links={navbarLinks} socialLinks={socialLinks} />
           <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
         </div>
-        <Footer links={navbarLinks} socialLinks={SOCIAL_LINKS} />
+        <Footer links={navbarLinks} socialLinks={socialLinks} />
       </body>
     </html>
   )

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,8 +4,7 @@ import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
-import type { SocialLink } from "@/components/Generic"
-import { payload } from "@/lib/payload"
+import { getSocialLinks } from "@/lib/payload"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -80,15 +79,7 @@ const navbarLinks: { label: string; href: string }[] = [
 export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 
-  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
-    slug: "social-links",
-  })
-  const socialLinks: SocialLink[] = [
-    { icon: "discord", label: "Discord", href: discordHref ?? "" },
-    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
-    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
-    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
-  ]
+  const socialLinks = await getSocialLinks()
 
   return (
     <html

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -1,10 +1,19 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
-import { SocialLinks } from "@/components/Generic"
+import { type SocialLink, SocialLinks } from "@/components/Generic"
 import { Button, Heading } from "@/components/Primitive"
-import { SOCIAL_LINKS } from "@/lib/constants"
+import { payload } from "@/lib/payload"
 
-export default function NotFoundPage() {
+export default async function NotFoundPage() {
+  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
+    slug: "social-links",
+  })
+  const socialLinks: SocialLink[] = [
+    { icon: "discord", label: "Discord", href: discordHref ?? "" },
+    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
+    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
+    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
+  ]
   return (
     <div className="flex grow flex-col items-center justify-center gap-30">
       <div className="flex max-w-64 flex-col items-center justify-center gap-6 text-center">
@@ -20,7 +29,7 @@ export default function NotFoundPage() {
       </div>
       <div className="flex flex-col items-center gap-3">
         <p className="paragraph-sm font-medium">Our Socials:</p>
-        <SocialLinks links={SOCIAL_LINKS} />
+        <SocialLinks links={socialLinks} />
       </div>
     </div>
   )

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -2,7 +2,7 @@ import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { SocialLinks } from "@/components/Generic"
 import { Button, Heading } from "@/components/Primitive"
-import { getSocialLinks } from "@/lib/payload"
+import { getSocialLinks } from "@/lib/helpers"
 
 export default async function NotFoundPage() {
   const socialLinks = await getSocialLinks()

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -1,19 +1,11 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
-import { type SocialLink, SocialLinks } from "@/components/Generic"
+import { SocialLinks } from "@/components/Generic"
 import { Button, Heading } from "@/components/Primitive"
-import { payload } from "@/lib/payload"
+import { getSocialLinks } from "@/lib/payload"
 
 export default async function NotFoundPage() {
-  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
-    slug: "social-links",
-  })
-  const socialLinks: SocialLink[] = [
-    { icon: "discord", label: "Discord", href: discordHref ?? "" },
-    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
-    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
-    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
-  ]
+  const socialLinks = await getSocialLinks()
   return (
     <div className="flex grow flex-col items-center justify-center gap-30">
       <div className="flex max-w-64 flex-col items-center justify-center gap-6 text-center">

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { AboutUsSection, HeroSection, ValuesSection, WhoWeAreSection } from "@/components/Composite"
-import { getSocialLinks, payload } from "@/lib/payload"
+import { getSocialLinks } from "@/lib/helpers"
+import { payload, Slugs } from "@/lib/payload"
 import type { Reel } from "@/payload/payload-types"
 import { SponsorsServerSection } from "./_components/SponsorsServerSection"
 
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function HomePage() {
   const [homePage, socialLinks] = await Promise.all([
-    payload.findGlobal({ slug: "home-page" }),
+    payload.findGlobal({ slug: Slugs.Globals.homePage }),
     getSocialLinks(),
   ])
 

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import { AboutUsSection, HeroSection, ValuesSection, WhoWeAreSection } from "@/components/Composite"
-import type { SocialLink } from "@/components/Generic"
-import { payload } from "@/lib/payload"
+import { getSocialLinks, payload } from "@/lib/payload"
 import type { Reel } from "@/payload/payload-types"
 import { SponsorsServerSection } from "./_components/SponsorsServerSection"
 
@@ -11,17 +10,10 @@ export const metadata: Metadata = {
 }
 
 export default async function HomePage() {
-  const [homePage, { discordHref, instagramHref, tiktokHref, linkedinHref }] = await Promise.all([
+  const [homePage, socialLinks] = await Promise.all([
     payload.findGlobal({ slug: "home-page" }),
-    payload.findGlobal({ slug: "social-links" }),
+    getSocialLinks(),
   ])
-
-  const socialLinks: SocialLink[] = [
-    { icon: "discord", label: "Discord", href: discordHref ?? "" },
-    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
-    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
-    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
-  ]
 
   const rawReels = (homePage?.reels ?? []) as (string | Reel | null | undefined)[]
   const resolvedReels: Reel[] = rawReels.filter((reel) => {

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { AboutUsSection, HeroSection, ValuesSection, WhoWeAreSection } from "@/components/Composite"
+import type { SocialLink } from "@/components/Generic"
 import { payload } from "@/lib/payload"
 import type { Reel } from "@/payload/payload-types"
 import { SponsorsServerSection } from "./_components/SponsorsServerSection"
@@ -10,9 +11,17 @@ export const metadata: Metadata = {
 }
 
 export default async function HomePage() {
-  const homePage = await payload.findGlobal({
-    slug: "home-page",
-  })
+  const [homePage, { discordHref, instagramHref, tiktokHref, linkedinHref }] = await Promise.all([
+    payload.findGlobal({ slug: "home-page" }),
+    payload.findGlobal({ slug: "social-links" }),
+  ])
+
+  const socialLinks: SocialLink[] = [
+    { icon: "discord", label: "Discord", href: discordHref ?? "" },
+    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
+    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
+    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
+  ]
 
   const rawReels = (homePage?.reels ?? []) as (string | Reel | null | undefined)[]
   const resolvedReels: Reel[] = rawReels.filter((reel) => {
@@ -25,7 +34,7 @@ export default async function HomePage() {
 
   return (
     <>
-      <HeroSection />
+      <HeroSection socialLinks={socialLinks} />
       <AboutUsSection reels={resolvedReels} />
       <WhoWeAreSection polaroids={resolvedPolaroids} />
       <ValuesSection />

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import { Heading } from "@/components/Primitive"
-import { payload } from "@/lib/payload"
+import { payload, Slugs } from "@/lib/payload"
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
@@ -19,7 +19,9 @@ type PrivacyPolicyGlobal = {
 }
 
 export default async function PrivacyPage() {
-  const policy = (await payload.findGlobal({ slug: "privacy-policy" })) as PrivacyPolicyGlobal
+  const policy = (await payload.findGlobal({
+    slug: Slugs.Globals.privacyPolicy,
+  })) as PrivacyPolicyGlobal
 
   const sections = policy.sections ?? []
   const updatedAt = policy.updatedAt ? new Date(policy.updatedAt) : null

--- a/src/app/(frontend)/sponsors/page.tsx
+++ b/src/app/(frontend)/sponsors/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import { Container, Heading, LazyImage } from "@/components/Primitive"
-import { payload } from "@/lib/payload"
+import { payload, Slugs } from "@/lib/payload"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
 import { SPONSOR_TIER_ORDER, SponsorTier } from "@/types/enums"
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function SponsorsPage() {
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
-    collection: "sponsor",
+    collection: Slugs.Collections.sponsor,
     depth: 2,
   })
 

--- a/src/app/(frontend)/team/page.tsx
+++ b/src/app/(frontend)/team/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { payload } from "@/lib/payload"
+import { payload, Slugs } from "@/lib/payload"
 import type { Executive } from "@/payload/payload-types"
 import { TeamPageClient } from "./_components/TeamPageClient"
 
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default async function TeamPage() {
   const execs: { docs: Executive[] } = await payload.find({
-    collection: "executive",
+    collection: Slugs.Collections.executive,
     limit: 100,
     depth: 2,
     sort: "createdAt",

--- a/src/components/Composite/HeroSection/HeroSection.tsx
+++ b/src/components/Composite/HeroSection/HeroSection.tsx
@@ -1,11 +1,10 @@
-import { SocialLinks } from "@/components/Generic"
+import { type SocialLink, SocialLinks } from "@/components/Generic"
 import { Heading } from "@/components/Primitive"
-import { SOCIAL_LINKS } from "@/lib/constants"
 
 /**
  * HeroSection component for the homepage.
  */
-export const HeroSection = () => {
+export const HeroSection = ({ socialLinks }: { socialLinks: SocialLink[] }) => {
   const START_YEAR = 2024
 
   return (
@@ -32,7 +31,7 @@ export const HeroSection = () => {
           </p>
         </div>
         <div className="mask-[linear-gradient(to_right,white,transparent)] hidden h-1.5 w-full bg-linear-to-r from-[#FF307C] to-[#2134FF] md:block" />
-        <SocialLinks links={SOCIAL_LINKS} />
+        <SocialLinks links={socialLinks} />
       </div>
     </section>
   )

--- a/src/components/Generic/SocialLinks/SocialLinks.stories.tsx
+++ b/src/components/Generic/SocialLinks/SocialLinks.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
-import { SOCIAL_LINKS } from "@/lib/constants"
 import { SocialLinks, type SocialLinksProps } from "./SocialLinks"
 
 const meta: Meta<SocialLinksProps> = {
@@ -10,7 +9,16 @@ const meta: Meta<SocialLinksProps> = {
     variant: { control: "radio", options: ["hero", "footer"] },
   },
   args: {
-    links: SOCIAL_LINKS,
+    links: [
+      { icon: "discord", label: "Discord", href: "https://discord.gg/HsG73WdWFm" },
+      { icon: "instagram", label: "Instagram", href: "https://www.instagram.com/uoacs25/" },
+      { icon: "tiktok", label: "TikTok", href: "https://www.tiktok.com/@uoacs?lang=en-GB" },
+      {
+        icon: "linkedin",
+        label: "LinkedIn",
+        href: "https://www.linkedin.com/company/university-of-auckland-compsci-society/posts/?feedView=all",
+      },
+    ],
   },
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,25 +1,4 @@
-import type { SocialLink } from "@/components/Generic"
-import { SOCIAL_ICONS } from "@/components/Primitive"
 import { SponsorTier } from "@/types/enums"
-
-export const SOCIAL_LINKS: SocialLink[] = [
-  { icon: SOCIAL_ICONS.Discord, label: "Discord", href: "https://discord.gg/HsG73WdWFm" },
-  {
-    icon: SOCIAL_ICONS.Instagram,
-    label: "Instagram",
-    href: "https://www.instagram.com/uoacs25/",
-  },
-  {
-    icon: SOCIAL_ICONS.TikTok,
-    label: "TikTok",
-    href: "https://www.tiktok.com/@uoacs?lang=en-GB",
-  },
-  {
-    icon: SOCIAL_ICONS.LinkedIn,
-    label: "LinkedIn",
-    href: "https://www.linkedin.com/company/university-of-auckland-compsci-society/posts/?feedView=all",
-  },
-]
 
 export const TIER_SIZES: Record<SponsorTier, { height: number; width: number }> = {
   [SponsorTier.DIAMOND]: {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,14 @@
+import type { SocialLink } from "@/components/Generic"
+import { payload } from "./payload"
+
+export async function getSocialLinks(): Promise<SocialLink[]> {
+  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
+    slug: "social-links",
+  })
+  return [
+    { icon: "discord", label: "Discord", href: discordHref ?? "" },
+    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
+    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
+    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
+  ]
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,9 +1,10 @@
 import type { SocialLink } from "@/components/Generic"
 import { payload } from "./payload"
+import { Slugs } from "./slugs"
 
 export async function getSocialLinks(): Promise<SocialLink[]> {
   const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
-    slug: "social-links",
+    slug: Slugs.Globals.socialLinks,
   })
   return [
     { icon: "discord", label: "Discord", href: discordHref ?? "" },

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,17 +1,4 @@
 import config from "@payload-config"
 import { getPayload, type Payload } from "payload"
-import type { SocialLink } from "@/components/Generic"
 
 export const payload: Payload = await getPayload({ config })
-
-export async function getSocialLinks(): Promise<SocialLink[]> {
-  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
-    slug: "social-links",
-  })
-  return [
-    { icon: "discord", label: "Discord", href: discordHref ?? "" },
-    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
-    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
-    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
-  ]
-}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,4 +1,17 @@
 import config from "@payload-config"
 import { getPayload, type Payload } from "payload"
+import type { SocialLink } from "@/components/Generic"
 
 export const payload: Payload = await getPayload({ config })
+
+export async function getSocialLinks(): Promise<SocialLink[]> {
+  const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
+    slug: "social-links",
+  })
+  return [
+    { icon: "discord", label: "Discord", href: discordHref ?? "" },
+    { icon: "instagram", label: "Instagram", href: instagramHref ?? "" },
+    { icon: "tiktok", label: "TikTok", href: tiktokHref ?? "" },
+    { icon: "linkedin", label: "LinkedIn", href: linkedinHref ?? "" },
+  ]
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -2,3 +2,5 @@ import config from "@payload-config"
 import { getPayload, type Payload } from "payload"
 
 export const payload: Payload = await getPayload({ config })
+
+export { type CollectionSlug, type GlobalSlug, type Slug, Slugs } from "./slugs"

--- a/src/lib/slugs.ts
+++ b/src/lib/slugs.ts
@@ -1,0 +1,20 @@
+export const Slugs = {
+  Collections: {
+    executive: "executive",
+    media: "media",
+    member: "member",
+    polaroid: "polaroid",
+    reel: "reel",
+    sponsor: "sponsor",
+    user: "user",
+  },
+  Globals: {
+    homePage: "home-page",
+    privacyPolicy: "privacy-policy",
+    socialLinks: "social-links",
+  },
+} as const
+
+export type CollectionSlug = (typeof Slugs.Collections)[keyof typeof Slugs.Collections]
+export type GlobalSlug = (typeof Slugs.Globals)[keyof typeof Slugs.Globals]
+export type Slug = CollectionSlug | GlobalSlug

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -15,6 +15,7 @@ import { Sponsor } from "./payload/collections/Sponsor"
 import { User } from "./payload/collections/User"
 import { HomePage } from "./payload/globals/HomePage"
 import { PrivacyPolicy } from "./payload/globals/PrivacyPolicy"
+import { SocialLinks } from "./payload/globals/SocialLinks"
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -28,7 +29,7 @@ export default buildConfig({
     },
   },
   collections: [User, Media, Member, Executive, Sponsor, Reel, Polaroid],
-  globals: [HomePage, PrivacyPolicy],
+  globals: [HomePage, PrivacyPolicy, SocialLinks],
   editor: lexicalEditor(),
   graphQL: {
     disable: true,

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -6,6 +6,7 @@ import { lexicalEditor } from "@payloadcms/richtext-lexical"
 import { s3Storage } from "@payloadcms/storage-s3"
 import { buildConfig } from "payload"
 import sharp from "sharp"
+import { Slugs } from "./lib/slugs"
 import { Executive } from "./payload/collections/Executive"
 import { Media } from "./payload/collections/Media"
 import { Member } from "./payload/collections/Member"
@@ -68,7 +69,7 @@ export default buildConfig({
     importExportPlugin({
       collections: [
         {
-          slug: "member",
+          slug: Slugs.Collections.member,
           export: {
             disableSave: true,
             disableJobsQueue: true,

--- a/src/payload/collections/Executive.ts
+++ b/src/payload/collections/Executive.ts
@@ -1,12 +1,13 @@
 import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { ExecutiveLevel, ExecutiveTeam } from "@/types/enums"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.team])
 
 export const Executive: CollectionConfig = {
-  slug: "executive",
+  slug: Slugs.Collections.executive,
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -1,7 +1,8 @@
 import type { CollectionConfig } from "payload"
+import { Slugs } from "@/lib/slugs"
 
 export const Media: CollectionConfig = {
-  slug: "media",
+  slug: Slugs.Collections.media,
   access: {
     read: () => true,
   },

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -1,7 +1,8 @@
 import type { CollectionConfig } from "payload"
+import { Slugs } from "@/lib/slugs"
 
 export const Member: CollectionConfig = {
-  slug: "member",
+  slug: Slugs.Collections.member,
   admin: {
     useAsTitle: "email",
   },

--- a/src/payload/collections/Polaroid.ts
+++ b/src/payload/collections/Polaroid.ts
@@ -1,11 +1,12 @@
 import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
 
 export const Polaroid: CollectionConfig = {
-  slug: "polaroid",
+  slug: Slugs.Collections.polaroid,
   admin: {
     useAsTitle: "caption",
   },

--- a/src/payload/collections/Reel.ts
+++ b/src/payload/collections/Reel.ts
@@ -1,11 +1,12 @@
 import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
 
 export const Reel: CollectionConfig = {
-  slug: "reel",
+  slug: Slugs.Collections.reel,
   admin: {
     useAsTitle: "description",
   },

--- a/src/payload/collections/Sponsor.ts
+++ b/src/payload/collections/Sponsor.ts
@@ -1,12 +1,13 @@
 import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { SponsorTier } from "@/types/enums"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.sponsors, Routes.home])
 
 export const Sponsor: CollectionConfig = {
-  slug: "sponsor",
+  slug: Slugs.Collections.sponsor,
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload/collections/User.ts
+++ b/src/payload/collections/User.ts
@@ -1,7 +1,8 @@
 import type { CollectionConfig } from "payload"
+import { Slugs } from "@/lib/slugs"
 
 export const User: CollectionConfig = {
-  slug: "user",
+  slug: Slugs.Collections.user,
   admin: {
     useAsTitle: "email",
   },

--- a/src/payload/globals/HomePage.ts
+++ b/src/payload/globals/HomePage.ts
@@ -1,11 +1,12 @@
 import type { GlobalConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
 const { globalAfterChange } = makeRevalidateHooks([Routes.home])
 
 export const HomePage: GlobalConfig = {
-  slug: "home-page",
+  slug: Slugs.Globals.homePage,
   fields: [
     {
       name: "reels",

--- a/src/payload/globals/PrivacyPolicy.ts
+++ b/src/payload/globals/PrivacyPolicy.ts
@@ -1,11 +1,12 @@
 import type { GlobalConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
 const { globalAfterChange } = makeRevalidateHooks([Routes.privacy])
 
 export const PrivacyPolicy: GlobalConfig = {
-  slug: "privacy-policy",
+  slug: Slugs.Globals.privacyPolicy,
   fields: [
     {
       name: "sections",

--- a/src/payload/globals/SocialLinks.ts
+++ b/src/payload/globals/SocialLinks.ts
@@ -1,5 +1,6 @@
 import type { GlobalConfig } from "payload"
 import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
 const { globalAfterChange } = makeRevalidateHooks([
@@ -10,7 +11,7 @@ const { globalAfterChange } = makeRevalidateHooks([
 ])
 
 export const SocialLinks: GlobalConfig = {
-  slug: "social-links",
+  slug: Slugs.Globals.socialLinks,
   fields: [
     {
       name: "discordHref",

--- a/src/payload/globals/SocialLinks.ts
+++ b/src/payload/globals/SocialLinks.ts
@@ -1,0 +1,41 @@
+import type { GlobalConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
+
+const { globalAfterChange } = makeRevalidateHooks([
+  Routes.home,
+  Routes.team,
+  Routes.sponsors,
+  Routes.privacy,
+])
+
+export const SocialLinks: GlobalConfig = {
+  slug: "social-links",
+  fields: [
+    {
+      name: "discordHref",
+      label: "Discord",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "instagramHref",
+      label: "Instagram",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "tiktokHref",
+      label: "TikTok",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "linkedinHref",
+      label: "LinkedIn",
+      type: "text",
+      required: true,
+    },
+  ],
+  hooks: { afterChange: [globalAfterChange] },
+}

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -106,10 +106,12 @@ export interface Config {
   globals: {
     'home-page': HomePage;
     'privacy-policy': PrivacyPolicy;
+    'social-links': SocialLink;
   };
   globalsSelect: {
     'home-page': HomePageSelect<false> | HomePageSelect<true>;
     'privacy-policy': PrivacyPolicySelect<false> | PrivacyPolicySelect<true>;
+    'social-links': SocialLinksSelect<false> | SocialLinksSelect<true>;
   };
   locale: null;
   widgets: {
@@ -876,6 +878,19 @@ export interface PrivacyPolicy {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "social-links".
+ */
+export interface SocialLink {
+  id: string;
+  discordHref: string;
+  instagramHref: string;
+  tiktokHref: string;
+  linkedinHref: string;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "home-page_select".
  */
 export interface HomePageSelect<T extends boolean = true> {
@@ -897,6 +912,19 @@ export interface PrivacyPolicySelect<T extends boolean = true> {
         content?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "social-links_select".
+ */
+export interface SocialLinksSelect<T extends boolean = true> {
+  discordHref?: T;
+  instagramHref?: T;
+  tiktokHref?: T;
+  linkedinHref?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;


### PR DESCRIPTION
# Description

This PR adds a `social-links` Payload global to make social link URLs editable through the admin panel, and introduces a \`Slugs\` const to eliminate hardcoded slug strings across the codebase.

- adds a new `SocialLinks` Payload global (slug: `social-links`) with four required `text` fields: `discordHref`, `instagramHref`, `tiktokHref`, `linkedinHref`
- registers the global in `payload.config.ts` and configures an `afterChange` revalidation hook that purges all public routes (`/`, `/team`, `/sponsors`, `/privacy`) on save
- removes the hardcoded `SOCIAL_LINKS` constant from `src/lib/constants.ts`
- adds `getSocialLinks()` helper in `src/lib/helpers.ts` that fetches the global and maps it to `SocialLink[]`
- updates `layout.tsx`, `page.tsx`, `not-found.tsx`, and `HeroSection` to use `getSocialLinks()` instead of the constant
- updates `HeroSection` to accept `socialLinks` as a prop rather than importing from constants
- adds a `Slugs` const in `src/lib/slugs.ts` with `Slugs.Collections.*` and `Slugs.Globals.*` entries for all Payload slugs, re-exported from `src/lib/payload.ts`
- replaces all hardcoded slug strings in collection configs, global configs, `payload.config.ts`, and frontend pages with `Slugs.*` references
- updates `SocialLinks.stories.tsx` to use inline hardcoded args instead of the removed constant

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member