### PR TITLE
refactor: use named constants for pages, routes etc

### DIFF
--- a/src/app/(frontend)/_components/SponsorsServerSection.tsx
+++ b/src/app/(frontend)/_components/SponsorsServerSection.tsx
@@ -4,7 +4,7 @@ import type { Sponsor } from "@/payload/payload-types"
 
 export const SponsorsServerSection = async () => {
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
-    collection: Slugs.Collections.sponsor,
+    collection: Slugs.Collections.SPONSOR,
   })
 
   return <SponsorsSection sponsors={sponsors} />

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -5,6 +5,7 @@ import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
 import { SOCIAL_LINKS } from "@/lib/constants"
+import { Routes } from "@/lib/routes"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -71,9 +72,9 @@ export const viewport: Viewport = {
 }
 
 const navbarLinks: { label: string; href: string }[] = [
-  { label: "Home", href: "/" },
-  { label: "Meet The Team", href: "/team" },
-  { label: "Our Sponsors", href: "/sponsors" },
+  { label: "Home", href: Routes.home },
+  { label: "Meet The Team", href: Routes.team },
+  { label: "Our Sponsors", href: Routes.sponsors },
 ]
 
 export default async function RootLayout(props: { children: React.ReactNode }) {

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -5,7 +5,7 @@ import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
 import { SOCIAL_LINKS } from "@/lib/constants"
-import { Routes } from "@/lib/routes"
+import { ApiRoutes, Routes } from "@/lib/routes"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
     locale: "en_NZ",
     images: [
       {
-        url: "/og",
+        url: ApiRoutes.og,
         width: 1200,
         height: 630,
         type: "image/png",
@@ -60,7 +60,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    images: ["/og"],
+    images: [ApiRoutes.og],
   },
 }
 

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
     locale: "en_NZ",
     images: [
       {
-        url: ApiRoutes.og,
+        url: ApiRoutes.OG,
         width: 1200,
         height: 630,
         type: "image/png",
@@ -60,7 +60,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    images: [ApiRoutes.og],
+    images: [ApiRoutes.OG],
   },
 }
 
@@ -72,9 +72,9 @@ export const viewport: Viewport = {
 }
 
 const navbarLinks: { label: string; href: string }[] = [
-  { label: "Home", href: Routes.home },
-  { label: "Meet The Team", href: Routes.team },
-  { label: "Our Sponsors", href: Routes.sponsors },
+  { label: "Home", href: Routes.HOME },
+  { label: "Meet The Team", href: Routes.TEAM },
+  { label: "Our Sponsors", href: Routes.SPONSORS },
 ]
 
 export default async function RootLayout(props: { children: React.ReactNode }) {

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { SocialLinks } from "@/components/Generic"
 import { Button, Heading } from "@/components/Primitive"
 import { SOCIAL_LINKS } from "@/lib/constants"
+import { Routes } from "@/lib/routes"
 
 export default function NotFoundPage() {
   return (
@@ -12,7 +13,7 @@ export default function NotFoundPage() {
           <Heading h={1}>404</Heading>
           <p className="paragraph">The page you are looking for does not exist.</p>
         </div>
-        <Link href="/">
+        <Link href={Routes.home}>
           <Button right={<ArrowRightIcon className="size-5" />} theme="dark">
             Go Home
           </Button>

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -13,7 +13,7 @@ export default function NotFoundPage() {
           <Heading h={1}>404</Heading>
           <p className="paragraph">The page you are looking for does not exist.</p>
         </div>
-        <Link href={Routes.home}>
+        <Link href={Routes.HOME}>
           <Button right={<ArrowRightIcon className="size-5" />} theme="dark">
             Go Home
           </Button>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function HomePage() {
   const [homePage, socialLinks] = await Promise.all([
-    payload.findGlobal({ slug: Slugs.Globals.homePage }),
+    payload.findGlobal({ slug: Slugs.Globals.HOME_PAGE }),
     getSocialLinks(),
   ])
 

--- a/src/app/(frontend)/privacy/page.tsx
+++ b/src/app/(frontend)/privacy/page.tsx
@@ -20,7 +20,7 @@ type PrivacyPolicyGlobal = {
 
 export default async function PrivacyPage() {
   const policy = (await payload.findGlobal({
-    slug: Slugs.Globals.privacyPolicy,
+    slug: Slugs.Globals.PRIVACY_POLICY,
   })) as PrivacyPolicyGlobal
 
   const sections = policy.sections ?? []

--- a/src/app/(frontend)/sponsors/page.tsx
+++ b/src/app/(frontend)/sponsors/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function SponsorsPage() {
   const { docs: sponsors }: { docs: Sponsor[] } = await payload.find({
-    collection: Slugs.Collections.sponsor,
+    collection: Slugs.Collections.SPONSOR,
     depth: 2,
   })
 

--- a/src/app/(frontend)/team/page.tsx
+++ b/src/app/(frontend)/team/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default async function TeamPage() {
   const execs: { docs: Executive[] } = await payload.find({
-    collection: Slugs.Collections.executive,
+    collection: Slugs.Collections.EXECUTIVE,
     limit: 100,
     depth: 2,
     sort: "createdAt",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next"
+import { Routes } from "@/lib/routes"
 
 export const dynamic = "force-static"
 
@@ -16,22 +17,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
-      url: `${baseUrl}/team`,
+      url: `${baseUrl}${Routes.team}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/sponsors`,
+      url: `${baseUrl}${Routes.sponsors}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/sign-up`,
+      url: `${baseUrl}${Routes.signUp}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/privacy`,
+      url: `${baseUrl}${Routes.privacy}`,
       lastModified: new Date(),
       priority: 0.5,
     },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,22 +17,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
-      url: `${baseUrl}${Routes.team}`,
+      url: `${baseUrl}${Routes.TEAM}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}${Routes.sponsors}`,
+      url: `${baseUrl}${Routes.SPONSORS}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}${Routes.signUp}`,
+      url: `${baseUrl}${Routes.SIGN_UP}`,
       lastModified: new Date(),
       priority: 0.8,
     },
     {
-      url: `${baseUrl}${Routes.privacy}`,
+      url: `${baseUrl}${Routes.PRIVACY}`,
       lastModified: new Date(),
       priority: 0.5,
     },

--- a/src/components/Composite/AboutUsSection/AboutUsSection.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { Button } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
 import type { Reel as ReelDocument } from "@/payload/payload-types"
 import { Reel } from "../Reel/Reel"
 
@@ -39,7 +40,7 @@ export const AboutUsSection = ({ reels }: AboutUsSectionProps) => {
           competitive events.
         </p>
         <div className="flex flex-col items-center gap-6 md:items-start">
-          <Link className="w-fit" href="/sign-up">
+          <Link className="w-fit" href={Routes.signUp}>
             <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Interested? Join UOACS
             </Button>

--- a/src/components/Composite/AboutUsSection/AboutUsSection.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.tsx
@@ -40,7 +40,7 @@ export const AboutUsSection = ({ reels }: AboutUsSectionProps) => {
           competitive events.
         </p>
         <div className="flex flex-col items-center gap-6 md:items-start">
-          <Link className="w-fit" href={Routes.signUp}>
+          <Link className="w-fit" href={Routes.SIGN_UP}>
             <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Interested? Join UOACS
             </Button>

--- a/src/components/Composite/Footer/Footer.stories.tsx
+++ b/src/components/Composite/Footer/Footer.stories.tsx
@@ -26,8 +26,8 @@ const meta: Meta<typeof Footer> = {
       },
     ],
     links: [
-      { label: "MEET THE TEAM", href: Routes.team },
-      { label: "OUR SPONSORS", href: Routes.sponsors },
+      { label: "MEET THE TEAM", href: Routes.TEAM },
+      { label: "OUR SPONSORS", href: Routes.SPONSORS },
     ],
   },
   argTypes: {

--- a/src/components/Composite/Footer/Footer.stories.tsx
+++ b/src/components/Composite/Footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
 import { SOCIAL_ICONS } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
 import { Footer } from "./Footer"
 
 const meta: Meta<typeof Footer> = {
@@ -25,8 +26,8 @@ const meta: Meta<typeof Footer> = {
       },
     ],
     links: [
-      { label: "MEET THE TEAM", href: "/team" },
-      { label: "OUR SPONSORS", href: "/sponsors" },
+      { label: "MEET THE TEAM", href: Routes.team },
+      { label: "OUR SPONSORS", href: Routes.sponsors },
     ],
   },
   argTypes: {

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react"
 import Link from "next/link"
 import type { SocialLink } from "@/components/Generic"
 import { Button, SocialIcon } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
 import { NavbarGradient } from "../Navbar/NavbarGradient"
 
@@ -29,7 +30,7 @@ export interface FooterProps {
  * @param className optional additional class names to apply to the button
  */
 const InterestedButton = ({ className }: { className?: string }) => (
-  <Link href="/sign-up">
+  <Link href={Routes.signUp}>
     <Button
       className={cn("whitespace-nowrap", className)}
       right={<ArrowUpRightIcon className="h-4 w-4 text-white" />}
@@ -56,7 +57,7 @@ export const Footer = ({ links, socialLinks }: FooterProps) => {
             <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>
             <Link
               className="paragraph-xs w-fit text-gray-400 transition-colors hover:text-white"
-              href="/privacy"
+              href={Routes.privacy}
             >
               Privacy Policy
             </Link>

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -30,7 +30,7 @@ export interface FooterProps {
  * @param className optional additional class names to apply to the button
  */
 const InterestedButton = ({ className }: { className?: string }) => (
-  <Link href={Routes.signUp}>
+  <Link href={Routes.SIGN_UP}>
     <Button
       className={cn("whitespace-nowrap", className)}
       right={<ArrowUpRightIcon className="h-4 w-4 text-white" />}
@@ -57,7 +57,7 @@ export const Footer = ({ links, socialLinks }: FooterProps) => {
             <p className="paragraph-sm text-gray-400">UOACS &copy; {new Date().getFullYear()}</p>
             <Link
               className="paragraph-xs w-fit text-gray-400 transition-colors hover:text-white"
-              href={Routes.privacy}
+              href={Routes.PRIVACY}
             >
               Privacy Policy
             </Link>

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -74,7 +74,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
           >
             <div className="flex w-full flex-row items-center justify-between px-4">
               <motion.div layoutId="navbar-logo">
-                <Link href={Routes.home} onClick={() => setIsOpen(false)}>
+                <Link href={Routes.HOME} onClick={() => setIsOpen(false)}>
                   <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
                 </Link>
               </motion.div>
@@ -101,7 +101,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                 </a>
               ))}
             </div>
-            <Link className="grid grid-cols-4" href={Routes.signUp}>
+            <Link className="grid grid-cols-4" href={Routes.SIGN_UP}>
               <Button className="col-span-4 rounded-b-none" theme="dark">
                 Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
               </Button>

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -7,6 +7,7 @@ import Image from "next/image"
 import Link, { type LinkProps } from "next/link"
 import { useEffect, useState } from "react"
 import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
 import type { NavbarProps } from "../Navbar"
 import { mobileNavbarVariants } from "./variants"
@@ -73,7 +74,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
           >
             <div className="flex w-full flex-row items-center justify-between px-4">
               <motion.div layoutId="navbar-logo">
-                <Link href="/" onClick={() => setIsOpen(false)}>
+                <Link href={Routes.home} onClick={() => setIsOpen(false)}>
                   <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
                 </Link>
               </motion.div>
@@ -100,7 +101,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                 </a>
               ))}
             </div>
-            <Link className="grid grid-cols-4" href="/sign-up">
+            <Link className="grid grid-cols-4" href={Routes.signUp}>
               <Button className="col-span-4 rounded-b-none" theme="dark">
                 Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
               </Button>

--- a/src/components/Composite/Navbar/Navbar.stories.tsx
+++ b/src/components/Composite/Navbar/Navbar.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
 import { SOCIAL_ICONS } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
 import { Navbar } from "./Navbar"
 
 const meta: Meta<typeof Navbar> = {
@@ -25,8 +26,8 @@ const meta: Meta<typeof Navbar> = {
       },
     ],
     links: [
-      { label: "MEET THE TEAM", href: "/team" },
-      { label: "OUR SPONSORS", href: "/sponsors" },
+      { label: "MEET THE TEAM", href: Routes.team },
+      { label: "OUR SPONSORS", href: Routes.sponsors },
     ],
   },
   argTypes: {

--- a/src/components/Composite/Navbar/Navbar.stories.tsx
+++ b/src/components/Composite/Navbar/Navbar.stories.tsx
@@ -26,8 +26,8 @@ const meta: Meta<typeof Navbar> = {
       },
     ],
     links: [
-      { label: "MEET THE TEAM", href: Routes.team },
-      { label: "OUR SPONSORS", href: Routes.sponsors },
+      { label: "MEET THE TEAM", href: Routes.TEAM },
+      { label: "OUR SPONSORS", href: Routes.SPONSORS },
     ],
   },
   argTypes: {

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -48,7 +48,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
       <NavbarGradient />
       <nav className="flex flex-row items-center justify-between">
         <motion.div layoutId="navbar-logo">
-          <Link className="z-50" href={Routes.home}>
+          <Link className="z-50" href={Routes.HOME}>
             <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
           </Link>
         </motion.div>
@@ -70,7 +70,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          <Link href={Routes.signUp}>
+          <Link href={Routes.SIGN_UP}>
             <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Join UOACS
             </Button>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -7,6 +7,7 @@ import Link from "next/link"
 import type { SocialLink } from "@/components/Generic"
 import { Button, Dropdown } from "@/components/Primitive"
 import { SocialIcon } from "@/components/Primitive/Icons"
+import { Routes } from "@/lib/routes"
 import { MobileNavbar } from "./MobileNavbar/MobileNavbar"
 import { NavbarGradient } from "./NavbarGradient"
 
@@ -47,7 +48,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
       <NavbarGradient />
       <nav className="flex flex-row items-center justify-between">
         <motion.div layoutId="navbar-logo">
-          <Link className="z-50" href="/">
+          <Link className="z-50" href={Routes.home}>
             <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
           </Link>
         </motion.div>
@@ -69,7 +70,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          <Link href="/sign-up">
+          <Link href={Routes.signUp}>
             <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
               Join UOACS
             </Button>

--- a/src/components/Composite/SignUpForm/SignUpForm.tsx
+++ b/src/components/Composite/SignUpForm/SignUpForm.tsx
@@ -10,7 +10,7 @@ import { Button, Radio } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
 import { MultiSelect } from "@/components/Primitive/MultiSelect/MultiSelect"
 import { Select } from "@/components/Primitive/Select/Select"
-import { Routes } from "@/lib/routes"
+import { ApiRoutes, Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import { createMemberSchema } from "@/types/schemas/member"
 
@@ -35,7 +35,7 @@ export const SignUpForm = () => {
     router.prefetch(Routes.home)
     setLoading(true)
     try {
-      const response = await fetch("/api/sign-up", {
+      const response = await fetch(ApiRoutes.signUp, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Composite/SignUpForm/SignUpForm.tsx
+++ b/src/components/Composite/SignUpForm/SignUpForm.tsx
@@ -10,6 +10,7 @@ import { Button, Radio } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
 import { MultiSelect } from "@/components/Primitive/MultiSelect/MultiSelect"
 import { Select } from "@/components/Primitive/Select/Select"
+import { Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import { createMemberSchema } from "@/types/schemas/member"
 
@@ -31,7 +32,7 @@ export const SignUpForm = () => {
   const router = useRouter()
 
   const onSubmit = async (data: FormOutput) => {
-    router.prefetch("/")
+    router.prefetch(Routes.home)
     setLoading(true)
     try {
       const response = await fetch("/api/sign-up", {
@@ -54,7 +55,7 @@ export const SignUpForm = () => {
         }
         return
       }
-      router.push("/")
+      router.push(Routes.home)
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",
       })
@@ -213,7 +214,7 @@ export const SignUpForm = () => {
 
       <p className="paragraph-xs text-gray-500">
         By signing up, you agree to our{" "}
-        <Link className="underline transition-colors hover:text-gray-700" href="/privacy">
+        <Link className="underline transition-colors hover:text-gray-700" href={Routes.privacy}>
           Privacy Policy
         </Link>
         .

--- a/src/components/Composite/SignUpForm/SignUpForm.tsx
+++ b/src/components/Composite/SignUpForm/SignUpForm.tsx
@@ -32,10 +32,10 @@ export const SignUpForm = () => {
   const router = useRouter()
 
   const onSubmit = async (data: FormOutput) => {
-    router.prefetch(Routes.home)
+    router.prefetch(Routes.HOME)
     setLoading(true)
     try {
-      const response = await fetch(ApiRoutes.signUp, {
+      const response = await fetch(ApiRoutes.SIGN_UP, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -55,7 +55,7 @@ export const SignUpForm = () => {
         }
         return
       }
-      router.push(Routes.home)
+      router.push(Routes.HOME)
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",
       })
@@ -214,7 +214,7 @@ export const SignUpForm = () => {
 
       <p className="paragraph-xs text-gray-500">
         By signing up, you agree to our{" "}
-        <Link className="underline transition-colors hover:text-gray-700" href={Routes.privacy}>
+        <Link className="underline transition-colors hover:text-gray-700" href={Routes.PRIVACY}>
           Privacy Policy
         </Link>
         .

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -70,7 +70,7 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
             if (!src) return null
 
             return (
-              <Link href={Routes.sponsors} key={sponsor.id}>
+              <Link href={Routes.SPONSORS} key={sponsor.id}>
                 <LazyImage
                   alt={sponsor.name || "Sponsor Logo"}
                   className="max-h-full max-w-full object-contain"
@@ -83,7 +83,7 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
           })}
         </div>
       )}
-      <Link href={Routes.sponsors}>
+      <Link href={Routes.SPONSORS}>
         <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
           See All Our Sponsors
         </Button>

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { SponsorTicker } from "@/components/Generic"
 import { Button, Heading, LazyImage } from "@/components/Primitive"
 import { TIER_SIZES } from "@/lib/constants"
+import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
 
@@ -69,7 +70,7 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
             if (!src) return null
 
             return (
-              <Link href="/sponsors" key={sponsor.id}>
+              <Link href={Routes.sponsors} key={sponsor.id}>
                 <LazyImage
                   alt={sponsor.name || "Sponsor Logo"}
                   className="max-h-full max-w-full object-contain"
@@ -82,7 +83,7 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
           })}
         </div>
       )}
-      <Link href="/sponsors">
+      <Link href={Routes.sponsors}>
         <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
           See All Our Sponsors
         </Button>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -4,7 +4,7 @@ import { Slugs } from "./slugs"
 
 export async function getSocialLinks(): Promise<SocialLink[]> {
   const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({
-    slug: Slugs.Globals.socialLinks,
+    slug: Slugs.Globals.SOCIAL_LINKS,
   })
   return [
     { icon: "discord", label: "Discord", href: discordHref ?? "" },

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,6 +3,7 @@ export const Routes = {
   team: "/team",
   sponsors: "/sponsors",
   privacy: "/privacy",
+  signUp: "/sign-up",
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,17 +1,17 @@
 export const Routes = {
-  home: "/",
-  team: "/team",
-  sponsors: "/sponsors",
-  privacy: "/privacy",
-  signUp: "/sign-up",
+  HOME: "/",
+  TEAM: "/team",
+  SPONSORS: "/sponsors",
+  PRIVACY: "/privacy",
+  SIGN_UP: "/sign-up",
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]
 
 export const ApiRoutes = {
-  signUp: "/api/sign-up",
-  health: "/api/health",
-  og: "/og",
+  SIGN_UP: "/api/sign-up",
+  HEALTH: "/api/health",
+  OG: "/og",
 } as const
 
 export type ApiRoute = (typeof ApiRoutes)[keyof typeof ApiRoutes]

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,3 +7,11 @@ export const Routes = {
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]
+
+export const ApiRoutes = {
+  signUp: "/api/sign-up",
+  health: "/api/health",
+  og: "/og",
+} as const
+
+export type ApiRoute = (typeof ApiRoutes)[keyof typeof ApiRoutes]

--- a/src/lib/slugs.ts
+++ b/src/lib/slugs.ts
@@ -1,17 +1,17 @@
 export const Slugs = {
   Collections: {
-    executive: "executive",
-    media: "media",
-    member: "member",
-    polaroid: "polaroid",
-    reel: "reel",
-    sponsor: "sponsor",
-    user: "user",
+    EXECUTIVE: "executive",
+    MEDIA: "media",
+    MEMBER: "member",
+    POLAROID: "polaroid",
+    REEL: "reel",
+    SPONSOR: "sponsor",
+    USER: "user",
   },
   Globals: {
-    homePage: "home-page",
-    privacyPolicy: "privacy-policy",
-    socialLinks: "social-links",
+    HOME_PAGE: "home-page",
+    PRIVACY_POLICY: "privacy-policy",
+    SOCIAL_LINKS: "social-links",
   },
 } as const
 

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -69,7 +69,7 @@ export default buildConfig({
     importExportPlugin({
       collections: [
         {
-          slug: Slugs.Collections.member,
+          slug: Slugs.Collections.MEMBER,
           export: {
             disableSave: true,
             disableJobsQueue: true,

--- a/src/payload/collections/Executive.ts
+++ b/src/payload/collections/Executive.ts
@@ -7,7 +7,7 @@ import { makeRevalidateHooks } from "../hooks/revalidate"
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.TEAM])
 
 export const Executive: CollectionConfig = {
-  slug: Slugs.Collections.executive,
+  slug: Slugs.Collections.EXECUTIVE,
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload/collections/Executive.ts
+++ b/src/payload/collections/Executive.ts
@@ -3,7 +3,7 @@ import { Routes } from "@/lib/routes"
 import { ExecutiveLevel, ExecutiveTeam } from "@/types/enums"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
-const { afterChange, afterDelete } = makeRevalidateHooks([Routes.team])
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.TEAM])
 
 export const Executive: CollectionConfig = {
   slug: "executive",

--- a/src/payload/collections/Media.ts
+++ b/src/payload/collections/Media.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload"
 import { Slugs } from "@/lib/slugs"
 
 export const Media: CollectionConfig = {
-  slug: Slugs.Collections.media,
+  slug: Slugs.Collections.MEDIA,
   access: {
     read: () => true,
   },

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload"
 import { Slugs } from "@/lib/slugs"
 
 export const Member: CollectionConfig = {
-  slug: Slugs.Collections.member,
+  slug: Slugs.Collections.MEMBER,
   admin: {
     useAsTitle: "email",
   },

--- a/src/payload/collections/Polaroid.ts
+++ b/src/payload/collections/Polaroid.ts
@@ -6,7 +6,7 @@ import { makeRevalidateHooks } from "../hooks/revalidate"
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.HOME])
 
 export const Polaroid: CollectionConfig = {
-  slug: Slugs.Collections.polaroid,
+  slug: Slugs.Collections.POLAROID,
   admin: {
     useAsTitle: "caption",
   },

--- a/src/payload/collections/Polaroid.ts
+++ b/src/payload/collections/Polaroid.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
-const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.HOME])
 
 export const Polaroid: CollectionConfig = {
   slug: "polaroid",

--- a/src/payload/collections/Reel.ts
+++ b/src/payload/collections/Reel.ts
@@ -6,7 +6,7 @@ import { makeRevalidateHooks } from "../hooks/revalidate"
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.HOME])
 
 export const Reel: CollectionConfig = {
-  slug: Slugs.Collections.reel,
+  slug: Slugs.Collections.REEL,
   admin: {
     useAsTitle: "description",
   },

--- a/src/payload/collections/Reel.ts
+++ b/src/payload/collections/Reel.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload"
 import { Routes } from "@/lib/routes"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
-const { afterChange, afterDelete } = makeRevalidateHooks([Routes.home])
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.HOME])
 
 export const Reel: CollectionConfig = {
   slug: "reel",

--- a/src/payload/collections/Sponsor.ts
+++ b/src/payload/collections/Sponsor.ts
@@ -3,7 +3,7 @@ import { Routes } from "@/lib/routes"
 import { SponsorTier } from "@/types/enums"
 import { makeRevalidateHooks } from "../hooks/revalidate"
 
-const { afterChange, afterDelete } = makeRevalidateHooks([Routes.sponsors, Routes.home])
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.SPONSORS, Routes.HOME])
 
 export const Sponsor: CollectionConfig = {
   slug: "sponsor",

--- a/src/payload/collections/Sponsor.ts
+++ b/src/payload/collections/Sponsor.ts
@@ -7,7 +7,7 @@ import { makeRevalidateHooks } from "../hooks/revalidate"
 const { afterChange, afterDelete } = makeRevalidateHooks([Routes.SPONSORS, Routes.HOME])
 
 export const Sponsor: CollectionConfig = {
-  slug: Slugs.Collections.sponsor,
+  slug: Slugs.Collections.SPONSOR,
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload/collections/User.ts
+++ b/src/payload/collections/User.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from "payload"
 import { Slugs } from "@/lib/slugs"
 
 export const User: CollectionConfig = {
-  slug: Slugs.Collections.user,
+  slug: Slugs.Collections.USER,
   admin: {
     useAsTitle: "email",
   },

--- a/src/payload/globals/HomePage.ts
+++ b/src/payload/globals/HomePage.ts
@@ -2,7 +2,7 @@ import type { GlobalConfig } from "payload"
 import { Routes } from "@/lib/routes"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
-const { globalAfterChange } = makeRevalidateHooks([Routes.home])
+const { globalAfterChange } = makeRevalidateHooks([Routes.HOME])
 
 export const HomePage: GlobalConfig = {
   slug: "home-page",

--- a/src/payload/globals/HomePage.ts
+++ b/src/payload/globals/HomePage.ts
@@ -6,7 +6,7 @@ import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 const { globalAfterChange } = makeRevalidateHooks([Routes.HOME])
 
 export const HomePage: GlobalConfig = {
-  slug: Slugs.Globals.homePage,
+  slug: Slugs.Globals.HOME_PAGE,
   fields: [
     {
       name: "reels",

--- a/src/payload/globals/PrivacyPolicy.ts
+++ b/src/payload/globals/PrivacyPolicy.ts
@@ -2,7 +2,7 @@ import type { GlobalConfig } from "payload"
 import { Routes } from "@/lib/routes"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
-const { globalAfterChange } = makeRevalidateHooks([Routes.privacy])
+const { globalAfterChange } = makeRevalidateHooks([Routes.PRIVACY])
 
 export const PrivacyPolicy: GlobalConfig = {
   slug: "privacy-policy",

--- a/src/payload/globals/PrivacyPolicy.ts
+++ b/src/payload/globals/PrivacyPolicy.ts
@@ -6,7 +6,7 @@ import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 const { globalAfterChange } = makeRevalidateHooks([Routes.PRIVACY])
 
 export const PrivacyPolicy: GlobalConfig = {
-  slug: Slugs.Globals.privacyPolicy,
+  slug: Slugs.Globals.PRIVACY_POLICY,
   fields: [
     {
       name: "sections",

--- a/src/payload/globals/SocialLinks.ts
+++ b/src/payload/globals/SocialLinks.ts
@@ -11,7 +11,7 @@ const { globalAfterChange } = makeRevalidateHooks([
 ])
 
 export const SocialLinks: GlobalConfig = {
-  slug: Slugs.Globals.socialLinks,
+  slug: Slugs.Globals.SOCIAL_LINKS,
   fields: [
     {
       name: "discordHref",

--- a/src/payload/globals/SocialLinks.ts
+++ b/src/payload/globals/SocialLinks.ts
@@ -4,10 +4,10 @@ import { Slugs } from "@/lib/slugs"
 import { makeRevalidateHooks } from "@/payload/hooks/revalidate"
 
 const { globalAfterChange } = makeRevalidateHooks([
-  Routes.home,
-  Routes.team,
-  Routes.sponsors,
-  Routes.privacy,
+  Routes.HOME,
+  Routes.TEAM,
+  Routes.SPONSORS,
+  Routes.PRIVACY,
 ])
 
 export const SocialLinks: GlobalConfig = {


### PR DESCRIPTION
# Description

This PR refactors hardcoded route strings and Payload slugs throughout the codebase to use typed constants, and migrates social links from a static array to a Payload-backed helper.

- renames all `Routes` keys to screaming snake case (e.g. `Routes.home` → `Routes.HOME`)
- adds `Routes.SIGN_UP` for the `/sign-up` page
- adds `ApiRoutes` constant with `SIGN_UP`, `HEALTH`, and `OG` entries
- adds `src/lib/slugs.ts` with a `Slugs` constant — `Slugs.Collections` and `Slugs.Globals` — for all Payload collection and global slugs, replacing inline string literals
- removes the static `SOCIAL_LINKS` array from `constants.ts` and replaces it with a `getSocialLinks()` async helper in `helpers.ts` that fetches hrefs from the `SocialLinks` Payload global
- re-exports `CollectionSlug`, `GlobalSlug`, `Slug`, and `Slugs` from `payload.ts` for convenience
- updates all components, layouts, stories, payload collections, and globals to use the above constants

Not related to a ticket

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
