### PR TITLE
fix(dropdown): add closing functionality outside of component

### DIFF
--- a/src/components/Primitive/Button/Button.tsx
+++ b/src/components/Primitive/Button/Button.tsx
@@ -9,6 +9,7 @@ export interface ButtonProps
     React.ButtonHTMLAttributes<HTMLButtonElement> {
   left?: React.ReactNode
   right?: React.ReactNode
+  ref?: React.Ref<HTMLButtonElement>
 }
 
 /**

--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { AnimatePresence, motion, stagger } from "motion/react"
-import { type ReactNode, useState } from "react"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { Button } from "../Button/Button"
 import type { ButtonVariantProps } from "../Button/variants"
@@ -49,9 +49,25 @@ export const Dropdown = ({
   ...buttonVariantProps
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return
+      }
+      setIsOpen(false)
+    }
+    document.addEventListener("mousedown", listener)
+    document.addEventListener("touchstart", listener)
+    return () => {
+      document.removeEventListener("mousedown", listener)
+      document.removeEventListener("touchstart", listener)
+    }
+  }, [])
 
   return (
-    <div className="relative inline-flex">
+    <div className="relative inline-flex" ref={ref}>
       <Button
         aria-expanded={isOpen}
         className={triggerClassName}

--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -70,7 +70,7 @@ export const Dropdown = ({
     <div className="relative inline-flex" ref={ref}>
       <Button
         aria-expanded={isOpen}
-        className={triggerClassName}
+        className={cn("z-20", triggerClassName)}
         onClick={() => setIsOpen(!isOpen)}
         right={
           triggerIcon || (
@@ -99,7 +99,7 @@ export const Dropdown = ({
           <motion.div
             animate="open"
             className={cn(
-              "absolute top-full right-0 z-10 mt-2 flex origin-top flex-col items-end gap-2 rounded-2xl",
+              "absolute top-full right-0 z-5 mt-2 flex origin-top flex-col items-end gap-2 rounded-2xl",
               popoverClassName,
             )}
             exit="closed"

--- a/src/components/Primitive/Dropdown/DropdownOption.tsx
+++ b/src/components/Primitive/Dropdown/DropdownOption.tsx
@@ -38,7 +38,7 @@ export const DropdownOption = ({ label, href, onClick, ...variant }: DropdownOpt
   }
 
   return (
-    <Button className="whitespace-nowrap" onClick={onClick} role="menuitem" {...variant}>
+    <Button className="z-5 whitespace-nowrap" onClick={onClick} role="menuitem" {...variant}>
       {label || "Option"}
     </Button>
   )


### PR DESCRIPTION
# Description

This PR fixes the `Dropdown` component to close when clicking outside and ensures options render below the trigger button.

- adds outside click/touch detection using a `useRef` + `useEffect` listener on `mousedown` and `touchstart`
- adds a `ref` prop to `ButtonProps` to support attaching refs to `Button` elements
- streamline z indices to ensure trigger takes priority over options during animation etc


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
