### PR TITLE
feat(reel): drive instagram link in Reel from SocialLinks global

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -25,10 +25,12 @@ export default async function HomePage() {
     return typeof polaroid === "object" && polaroid !== null
   })
 
+  const instagramHref = socialLinks.find((l) => l.icon === "instagram")?.href ?? ""
+
   return (
     <>
       <HeroSection socialLinks={socialLinks} />
-      <AboutUsSection reels={resolvedReels} />
+      <AboutUsSection instagramHref={instagramHref} reels={resolvedReels} />
       <WhoWeAreSection polaroids={resolvedPolaroids} />
       <ValuesSection />
       <SponsorsServerSection />

--- a/src/components/Composite/AboutUsSection/AboutUsSection.stories.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof AboutUsSection> = {
   component: AboutUsSection,
   args: {
     reels: [mockReel, mockReel],
+    instagramHref: "https://www.instagram.com/uoacs25/",
   },
 }
 

--- a/src/components/Composite/AboutUsSection/AboutUsSection.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.tsx
@@ -13,6 +13,10 @@ export interface AboutUsSectionProps {
    * An array of reels to display in the About Us section.
    */
   reels: ReelDocument[]
+  /**
+   * The Instagram profile URL, passed through to each {@link Reel}.
+   */
+  instagramHref: string
 }
 
 /**
@@ -20,7 +24,7 @@ export interface AboutUsSectionProps {
  *
  * @param reels An array of reels to display in the About Us section.
  */
-export const AboutUsSection = ({ reels }: AboutUsSectionProps) => {
+export const AboutUsSection = ({ reels, instagramHref }: AboutUsSectionProps) => {
   return (
     <div className="flex w-full flex-row justify-between gap-18 overflow-x-visible">
       <div className="flex w-full flex-none flex-col items-center gap-8 md:w-auto md:max-w-lg md:items-start md:gap-12">
@@ -51,7 +55,7 @@ export const AboutUsSection = ({ reels }: AboutUsSectionProps) => {
       <div className="hidden flex-none md:flex">
         <div className="flex h-full flex-row flex-nowrap justify-start gap-4 overflow-x-visible">
           {reels.map((reel) => (
-            <Reel key={reel.id} reel={reel} />
+            <Reel instagramHref={instagramHref} key={reel.id} reel={reel} />
           ))}
         </div>
       </div>

--- a/src/components/Composite/Reel/Reel.stories.tsx
+++ b/src/components/Composite/Reel/Reel.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof Reel> = {
   },
   args: {
     reel: mockReel,
+    instagramHref: "https://www.instagram.com/uoacs25/",
   },
 }
 
@@ -24,7 +25,7 @@ export const Primary: Story = (args) => {
   )
 }
 
-export const LongDescription: Story = ({ reel }) => {
+export const LongDescription: Story = ({ reel, instagramHref }) => {
   const longDescriptionReel = {
     ...reel,
     description:
@@ -33,7 +34,7 @@ export const LongDescription: Story = ({ reel }) => {
 
   return (
     <div className="w-80">
-      <Reel reel={longDescriptionReel} />
+      <Reel instagramHref={instagramHref} reel={longDescriptionReel} />
     </div>
   )
 }

--- a/src/components/Composite/Reel/Reel.tsx
+++ b/src/components/Composite/Reel/Reel.tsx
@@ -13,6 +13,10 @@ export interface ReelProps {
    * The {@link ReelType} data including video and description.
    */
   reel: ReelType
+  /**
+   * The Instagram profile URL, used for the handle link.
+   */
+  instagramHref: string
 }
 
 /**
@@ -21,8 +25,9 @@ export interface ReelProps {
  * @param {ReelType} reel The reel data including video and description.
  * @returns The rendered Reel component.
  */
-export const Reel = ({ reel }: ReelProps) => {
+export const Reel = ({ reel, instagramHref }: ReelProps) => {
   const src = typeof reel.video === "string" ? reel.video : reel.video?.url || ""
+  const handle = instagramHref.replace(/\/$/, "").split("/").pop() ?? ""
 
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
@@ -46,9 +51,9 @@ export const Reel = ({ reel }: ReelProps) => {
 
       <div className="paragraph-sm absolute bottom-0 left-0 p-4 text-white">
         <a
-          aria-label="Visit our Instagram Page @uoacs25"
+          aria-label={`Visit our Instagram Page @${handle}`}
           className="mb-2 flex items-center gap-2 p-0 font-semibold drop-shadow-md"
-          href="https://www.instagram.com/uoacs25/"
+          href={instagramHref}
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -59,7 +64,7 @@ export const Reel = ({ reel }: ReelProps) => {
             src="/uoacs-icon.svg"
             width={32}
           />
-          <span>uoacs25</span>
+          <span>{handle}</span>
         </a>
         <button
           className={cn(


### PR DESCRIPTION
# Description

This PR makes the Instagram link and handle in the `Reel` component dynamic, sourcing both from the `SocialLinks` Payload global instead of hardcoded values.

- updates `ReelProps` to accept an `instagramHref` prop and derives the display handle from it by stripping the trailing slash and extracting the last path segment
- updates `AboutUsSectionProps` to accept and pass through an `instagramHref` prop to each `Reel`
- updates `page.tsx` to look up the Instagram entry from `socialLinks` and pass its `href` down to `AboutUsSection`
- updates `Reel.stories.tsx` and `AboutUsSection.stories.tsx` with the `instagramHref` arg so stories render correctly

Not related to a ticket

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member