### PR TITLE
fix(fonts): use optional display and widen hero section max-width

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -11,14 +11,14 @@ const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
   weight: "100 900",
   variable: "--font-inter",
-  display: "swap",
+  display: "optional",
 })
 
 const switzer = localFont({
   src: "../../../public/fonts/Switzer-Variable.woff2",
   weight: "100 900",
   variable: "--font-switzer",
-  display: "swap",
+  display: "optional",
 })
 
 const mono = localFont({
@@ -35,7 +35,7 @@ const mono = localFont({
     },
   ],
   variable: "--font-mono",
-  display: "swap",
+  display: "optional",
 })
 
 export const metadata: Metadata = {

--- a/src/components/Composite/HeroSection/HeroSection.tsx
+++ b/src/components/Composite/HeroSection/HeroSection.tsx
@@ -16,7 +16,7 @@ export const HeroSection = ({ socialLinks }: { socialLinks: SocialLink[] }) => {
         <br />
         EST. {START_YEAR}
       </p>
-      <div className="flex flex-col justify-center gap-12 md:max-w-[32rem] md:justify-start">
+      <div className="flex flex-col justify-center gap-12 md:max-w-[38rem] md:justify-start">
         <div className="flex flex-col justify-center gap-6 text-center md:gap-12 md:text-left">
           <div className="self-center md:self-start">
             <Heading className="md:justify-start md:text-left" h={2}>


### PR DESCRIPTION
This PR fixes font display issues by switching from `swap` to `optional` font display and widens the hero section container to prevent text overflow.

- changes all three local font declarations (`inter`, `switzer`, `mono`) in `src/app/(frontend)/layout.tsx` from `display: "swap"` to `display: "optional"` to prevent layout shift caused by late-loading fonts
- increases the hero section container max-width from `md:max-w-[32rem]` to `md:max-w-[38rem]` in `HeroSection.tsx` to give heading text more room on medium and larger screens

**Ticket:** Not related to a ticket.

## How to test this change

1. Run the development server with `pnpm dev`.
2. Navigate to the home page at `/`.
3. Observe the hero section — the heading text should not be clipped or wrapped unexpectedly at medium screen widths.
4. Throttle the network in DevTools to simulate a slow connection. With `display: "optional"`, the page should render with the fallback font without a visible flash or layout shift when the custom font loads.