### PR TITLE
feat(lefthook): add post-checkout hook for dependency installation

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -13,6 +13,15 @@ pre-commit:
         - "pnpm-lock.yaml"
         - "**/importMap.js"
         - "**/payload-types.ts"
+        - "**/*.md"
+        - "**/.github/"
+        - "**/.next"
+        - "**/dist"
+        - "**/.turbo"
+        - "**/.vscode"
+        - "**/coverage"
+        - "**/.vercel"
+        - "**/node_modules"
       run: |
         pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -16,3 +16,9 @@ pre-commit:
       run: |
         pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
+
+post-checkout:
+  commands:
+    pnpm:
+      glob: "{package.json,pnpm-lock.yaml}"
+      run: pnpm install


### PR DESCRIPTION
# Description

This PR adds a `post-checkout` hook to lefthook that runs `pnpm install` when `package.json` or `pnpm-lock.yaml` are affected by a checkout, mirroring the existing `post-merge` behaviour. It also adds the same exclude patterns to the `pre-commit` biome command that biome itself ignores (e.g. `**/node_modules`, `**/.next`, `**/dist`), ensuring lefthook doesn't pass those paths to biome unnecessarily.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
