### PR TITLE
feat(.github): add a workflow to backport commits from renovate workflows onto the latest release branch

### DIFF
--- a/.github/actions/cherry-pick-and-pr/action.yaml
+++ b/.github/actions/cherry-pick-and-pr/action.yaml
@@ -1,0 +1,256 @@
+name: Cherry-pick and Create PR
+description: >
+  Cherry-picks commits from a merged PR onto a target branch and opens a PR.
+  Requires the calling workflow to have checked out with fetch-depth: 0 and a token.
+
+inputs:
+  merge-commit-sha:
+    required: true
+    description: SHA of the merge commit
+  base-sha:
+    required: true
+    description: Base SHA of the PR (used to determine the commit range)
+  pr-number:
+    required: true
+    description: Original PR number
+  source-branch:
+    required: true
+    description: Branch the PR was merged into (used in the created PR body)
+  target-branch:
+    required: true
+    description: Branch to cherry-pick onto
+  forward-branch-prefix:
+    required: false
+    default: pr-forward
+    description: Prefix for the created branch name
+  base-label:
+    required: false
+    default: pr-forward
+    description: Base label applied to the created PR
+  pr-title-prefix:
+    required: false
+    default: '[PR Forward]'
+    description: Prefix for the created PR title
+  github-token:
+    required: true
+    description: Token for PR creation and git push
+
+outputs:
+  pr-url:
+    description: URL of the created PR
+    value: ${{ steps.create-pr.outputs.pr-url }}
+  branch-name:
+    description: Name of the created branch
+    value: ${{ steps.cherry-pick.outputs.branch_name }}
+  conflict:
+    description: 'true if cherry-pick had conflicts'
+    value: ${{ steps.cherry-pick.outputs.conflict }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Cherry-pick commits onto target branch
+      id: cherry-pick
+      shell: bash
+      env:
+        MERGE_COMMIT: ${{ inputs.merge-commit-sha }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        FORWARD_BRANCH_PREFIX: ${{ inputs.forward-branch-prefix }}
+      run: |
+        set -e
+
+        # Sanitize target branch name for use in the branch name (replace / with -)
+        TARGET_BRANCH_SLUG="${TARGET_BRANCH//\//-}"
+        BRANCH_NAME="${FORWARD_BRANCH_PREFIX}/pr-${PR_NUMBER}-to-${TARGET_BRANCH_SLUG}"
+
+        echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+        # Delete remote branch if it exists (allows re-runs)
+        if ! DELETE_OUTPUT=$(git push origin --delete "$BRANCH_NAME" 2>&1); then
+          if ! echo "$DELETE_OUTPUT" | grep -q "remote ref does not exist"; then
+            echo "Failed to delete remote branch '$BRANCH_NAME': $DELETE_OUTPUT" >&2
+            exit 1
+          fi
+        fi
+
+        # Checkout target branch and create new branch
+        git switch "$TARGET_BRANCH"
+        git pull origin "$TARGET_BRANCH"
+        git switch -c "$BRANCH_NAME"
+
+        # Determine commits to cherry-pick based on merge strategy
+        # For merge commits: get commits from the merged branch
+        # For squash commits: use the squash commit itself
+        if git rev-parse "$MERGE_COMMIT^2" >/dev/null 2>&1; then
+          # Merge commit - get the commits from the feature branch
+          COMMITS=$(git log --reverse --format="%H" "$BASE_SHA".."$MERGE_COMMIT^2")
+        else
+          # Squash merge - use the merge commit directly
+          COMMITS="$MERGE_COMMIT"
+        fi
+
+        if [ -z "$COMMITS" ]; then
+          echo "No commits found to cherry-pick"
+          COMMITS="$MERGE_COMMIT"
+        fi
+
+        echo "Commits to cherry-pick:"
+        echo "$COMMITS"
+
+        # Cherry-pick each commit individually (preserves history)
+        FAILED=false
+        FAILED_COMMIT=""
+        for COMMIT in $COMMITS; do
+          echo "Cherry-picking $COMMIT"
+          if ! git cherry-pick "$COMMIT"; then
+            FAILED=true
+            FAILED_COMMIT="$COMMIT"
+            break
+          fi
+        done
+
+        if [ "$FAILED" = true ]; then
+          echo "conflict=true" >> $GITHUB_OUTPUT
+
+          # Abort the failed cherry-pick
+          git cherry-pick --abort || true
+
+          # Reset branch to clean state
+          git reset --hard "$TARGET_BRANCH"
+
+          # Create a marker file with instructions
+          cat > PR_FORWARD_CONFLICT.md << EOF
+        # PR Forward Conflict
+
+        Cherry-pick failed on commit: \`$FAILED_COMMIT\`
+
+        ## Original PR: #${PR_NUMBER}
+
+        ## Commits to cherry-pick:
+        \`\`\`
+        $COMMITS
+        \`\`\`
+
+        ## Manual resolution steps:
+        1. Check out this branch: \`git checkout $BRANCH_NAME\`
+        2. Cherry-pick manually: \`git cherry-pick $FAILED_COMMIT\`
+        3. Resolve conflicts
+        4. Continue with remaining commits if any
+        5. Delete this file and push
+        EOF
+          git add PR_FORWARD_CONFLICT.md
+          git commit -m "chore: forward PR #${PR_NUMBER} (CONFLICTS - manual resolution required)"
+        else
+          echo "conflict=false" >> $GITHUB_OUTPUT
+
+          # Check if we actually have changes (might already be in target branch)
+          if git diff --quiet "$TARGET_BRANCH"; then
+            echo "No changes to cherry-pick - changes may already be in $TARGET_BRANCH"
+            echo "no_changes=true" >> $GITHUB_OUTPUT
+            git commit --allow-empty -m "chore: forward PR #${PR_NUMBER} (no changes - already in ${TARGET_BRANCH})"
+          else
+            echo "no_changes=false" >> $GITHUB_OUTPUT
+          fi
+        fi
+
+        git push -u origin "$BRANCH_NAME"
+
+    - name: Create Pull Request
+      id: create-pr
+      uses: actions/github-script@v6
+      env:
+        BASE_LABEL: ${{ inputs.base-label }}
+        PR_TITLE_PREFIX: ${{ inputs.pr-title-prefix }}
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        PR_NUMBER_INPUT: ${{ inputs.pr-number }}
+        BRANCH_NAME: ${{ steps.cherry-pick.outputs.branch_name }}
+        HAS_CONFLICT: ${{ steps.cherry-pick.outputs.conflict }}
+        NO_CHANGES: ${{ steps.cherry-pick.outputs.no_changes }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const hasConflict = process.env.HAS_CONFLICT === 'true';
+          const noChanges = process.env.NO_CHANGES === 'true';
+          const originalPR = parseInt(process.env.PR_NUMBER_INPUT);
+          const sourceBranch = process.env.SOURCE_BRANCH;
+          const targetBranch = process.env.TARGET_BRANCH;
+          const branchName = process.env.BRANCH_NAME;
+          const baseLabel = process.env.BASE_LABEL;
+          const titlePrefix = process.env.PR_TITLE_PREFIX;
+
+          // Safely get title - avoid template literal injection
+          const originalTitle = context.payload.pull_request.title;
+
+          let title, body, labels;
+
+          if (noChanges) {
+            title = `${titlePrefix} ${originalTitle}`;
+            body = `## Automatic PR forward from \`${sourceBranch}\`
+
+          > **No changes detected** - these changes may already be in \`${targetBranch}\`.
+
+          Please verify and close this PR if the changes are already present.
+
+          ---
+          Original PR: #${originalPR}`;
+            labels = [baseLabel, 'no-changes'];
+          } else if (hasConflict) {
+            title = `${titlePrefix} ${originalTitle}`;
+            body = `## Automatic PR forward from \`${sourceBranch}\`
+
+          > **Cherry-pick had conflicts and requires manual resolution**
+
+          This PR was automatically created to forward PR changes from #${originalPR}.
+
+          ### Manual steps required:
+          1. Check out this branch locally:
+             \`\`\`bash
+             git fetch origin
+             git checkout ${branchName}
+             \`\`\`
+          2. See \`PR_FORWARD_CONFLICT.md\` for the commits that need cherry-picking
+          3. Cherry-pick and resolve conflicts
+          4. Delete \`PR_FORWARD_CONFLICT.md\`
+          5. Push your changes
+
+          ---
+          Original PR: #${originalPR}`;
+            labels = [baseLabel, 'needs-manual-resolution'];
+          } else {
+            title = `${titlePrefix} ${originalTitle}`;
+            body = `## Automatic PR forward from \`${sourceBranch}\`
+
+          This PR was automatically created to forward PR changes from #${originalPR} to \`${targetBranch}\`.
+
+          ---
+          Original PR: #${originalPR}`;
+            labels = [baseLabel];
+          }
+
+          const pr = await github.rest.pulls.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: title,
+            body: body,
+            head: branchName,
+            base: targetBranch
+          });
+
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.data.number,
+            labels: labels
+          });
+
+          core.setOutput('pr-url', pr.data.html_url);
+          console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`);

--- a/.github/workflows/forward-pr.yaml
+++ b/.github/workflows/forward-pr.yaml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   forward-pr:
-    # Only run this job if the PR was merged
-    if: github.event.pull_request.merged == true
+    # Only run if merged, and not a renovate-backport PR (those already came from main)
+    if: github.event.pull_request.merged == true && !startsWith(github.event.pull_request.head.ref, 'renovate-backport/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,182 +22,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create PR forward branch and cherry-pick
-        id: cherry-pick
-        run: |
-          set -e
-
-          MERGE_COMMIT=${{ github.event.pull_request.merge_commit_sha }}
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          BRANCH_NAME="pr-forward/pr-${PR_NUMBER}-to-main"
-
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
-          # Delete remote branch if it exists (allows re-runs)
-          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
-
-          # Checkout main and create new branch
-          git switch main
-          git pull origin main
-          git switch -c "$BRANCH_NAME"
-
-          # Determine commits to cherry-pick based on merge strategy
-          # For merge commits: get commits from the merged branch
-          # For squash commits: use the squash commit itself
-          if git rev-parse "$MERGE_COMMIT^2" >/dev/null 2>&1; then
-            # Merge commit - get the commits from the feature branch
-            COMMITS=$(git log --reverse --format="%H" "$BASE_SHA".."$MERGE_COMMIT^2")
-          else
-            # Squash merge - use the merge commit directly
-            COMMITS="$MERGE_COMMIT"
-          fi
-
-          if [ -z "$COMMITS" ]; then
-            echo "No commits found to cherry-pick"
-            COMMITS="$MERGE_COMMIT"
-          fi
-
-          echo "Commits to cherry-pick:"
-          echo "$COMMITS"
-
-          # Cherry-pick each commit individually (preserves history)
-          FAILED=false
-          FAILED_COMMIT=""
-          for COMMIT in $COMMITS; do
-            echo "Cherry-picking $COMMIT"
-            if ! git cherry-pick "$COMMIT"; then
-              FAILED=true
-              FAILED_COMMIT="$COMMIT"
-              break
-            fi
-          done
-
-          if [ "$FAILED" = true ]; then
-            echo "conflict=true" >> $GITHUB_OUTPUT
-
-            # Abort the failed cherry-pick
-            git cherry-pick --abort || true
-
-            # Reset branch to clean state
-            git reset --hard main
-
-            # Create a marker file with instructions
-            cat > PR_FORWARD_CONFLICT.md << EOF
-          # PR Forward Conflict
-
-          Cherry-pick failed on commit: \`$FAILED_COMMIT\`
-
-          ## Original PR: #${PR_NUMBER}
-
-          ## Commits to cherry-pick:
-          \`\`\`
-          $COMMITS
-          \`\`\`
-
-          ## Manual resolution steps:
-          1. Check out this branch: \`git checkout $BRANCH_NAME\`
-          2. Cherry-pick manually: \`git cherry-pick $FAILED_COMMIT\`
-          3. Resolve conflicts
-          4. Continue with remaining commits if any
-          5. Delete this file and push
-          EOF
-            git add PR_FORWARD_CONFLICT.md
-            git commit -m "chore: forward PR PR #${PR_NUMBER} (CONFLICTS - manual resolution required)"
-          else
-            echo "conflict=false" >> $GITHUB_OUTPUT
-
-            # Check if we actually have changes (might already be in main)
-            if git diff --quiet main; then
-              echo "No changes to forward PR - changes may already be in main"
-              echo "no_changes=true" >> $GITHUB_OUTPUT
-              # Still push the branch so we can create a PR noting this
-              git commit --allow-empty -m "chore: forward PR PR #${PR_NUMBER} (no changes - already in main)"
-            else
-              echo "no_changes=false" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-          git push -u origin "$BRANCH_NAME"
-
-      - name: Create Pull Request
-        uses: actions/github-script@v6
+      - name: Cherry-pick and create forward PR
+        uses: ./.github/actions/cherry-pick-and-pr
         with:
-          script: |
-            const hasConflict = '${{ steps.cherry-pick.outputs.conflict }}' === 'true';
-            const noChanges = '${{ steps.cherry-pick.outputs.no_changes }}' === 'true';
-            const originalPR = ${{ github.event.pull_request.number }};
-            const sourceBranch = '${{ github.event.pull_request.base.ref }}';
-            const branchName = '${{ steps.cherry-pick.outputs.branch_name }}';
-
-            // Safely get title - avoid template literal injection
-            const originalTitle = context.payload.pull_request.title;
-
-            let title, body, labels;
-
-            if (noChanges) {
-              title = `[PR Forward] ${originalTitle}`;
-              body = `## Automatic PR forward from \`${sourceBranch}\`
-
-            > **No changes detected** - these changes may already be in \`main\`.
-
-            Please verify and close this PR if the changes are already present.
-
-            ---
-            Original PR: #${originalPR}`;
-              labels = ['pr-forward', 'no-changes'];
-            } else if (hasConflict) {
-              title = `[PR Forward] ${originalTitle}`;
-              body = `## Automatic PR forward from \`${sourceBranch}\`
-
-            > **Cherry-pick had conflicts and requires manual resolution**
-
-            This PR was automatically created to forward PR changes from #${originalPR}.
-
-            ### Manual steps required:
-            1. Check out this branch locally:
-               \`\`\`bash
-               git fetch origin
-               git checkout ${branchName}
-               \`\`\`
-            2. See \`PR_FORWARD_CONFLICT.md\` for the commits that need cherry-picking
-            3. Cherry-pick and resolve conflicts
-            4. Delete \`PR_FORWARD_CONFLICT.md\`
-            5. Push your changes
-
-            ---
-            Original PR: #${originalPR}`;
-              labels = ['pr-forward', 'needs-manual-resolution'];
-            } else {
-              title = `[PR Forward] ${originalTitle}`;
-              body = `## Automatic PR forward from \`${sourceBranch}\`
-
-            This PR was automatically created to forward PR changes from #${originalPR} to \`main\`.
-
-            ---
-            Original PR: #${originalPR}`;
-              labels = ['pr-forward'];
-            }
-
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: body,
-              head: branchName,
-              base: 'main'
-            });
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.data.number,
-              labels: labels
-            });
-
-            console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`);
+          merge-commit-sha: ${{ github.event.pull_request.merge_commit_sha }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          pr-number: ${{ github.event.pull_request.number }}
+          source-branch: ${{ github.event.pull_request.base.ref }}
+          target-branch: main
+          forward-branch-prefix: pr-forward
+          base-label: pr-forward
+          pr-title-prefix: '[PR Forward]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate-backport.yaml
+++ b/.github/workflows/renovate-backport.yaml
@@ -1,0 +1,52 @@
+name: Renovate Backport to Release Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate-backport:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect latest release branch
+        id: detect-release
+        run: |
+          LATEST=$(git branch -r | grep -E 'origin/release/v[0-9]+\.[0-9]+\.x$' | sort -V | tail -1 | xargs | sed 's|origin/||')
+          if [ -z "$LATEST" ]; then
+            echo "No concrete release branch found, skipping backport"
+            echo "branch=" >> $GITHUB_OUTPUT
+          else
+            echo "Latest release branch: $LATEST"
+            echo "branch=$LATEST" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if no release branch
+        if: steps.detect-release.outputs.branch == ''
+        run: echo "No release branch detected — nothing to backport."
+
+      - name: Cherry-pick and create backport PR
+        if: steps.detect-release.outputs.branch != ''
+        uses: ./.github/actions/cherry-pick-and-pr
+        with:
+          merge-commit-sha: ${{ github.event.pull_request.merge_commit_sha }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          pr-number: ${{ github.event.pull_request.number }}
+          source-branch: main
+          target-branch: ${{ steps.detect-release.outputs.branch }}
+          forward-branch-prefix: renovate-backport
+          base-label: renovate-backport
+          pr-title-prefix: '[Renovate Backport]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This PR introduces a renovate dependency backport workflow and extracts the shared cherry-pick logic into a reusable composite action.

- extracts the inline cherry-pick and PR creation script from `forward-pr.yaml` into a composite action at `.github/actions/cherry-pick-and-pr`
  - parameterised for `forward-branch-prefix`, `base-label`, `pr-title-prefix`, and `target-branch` so it can be reused across workflows
  - improves error handling on the `git push origin --delete` step so auth/permission failures surface instead of being silently swallowed
- simplifies `forward-pr.yaml` from 193 lines to 36 by delegating to the composite action
  - adds a condition to skip `renovate-backport/` branches to prevent an infinite forwarding loop (backport PRs already came from `main`)
- adds `renovate-backport.yaml` which triggers when a `renovate/*` PR merges into `main` and cherry-picks it onto the latest `release/v*.*.x` branch
  - detects the latest release branch at runtime via `git branch -r` + version sort


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Cant lie i aint really tested it but claude's pretty happy with its work and as long as the pr-forward workflow still works its not impacting any existing work (hopefully). plus its not really a change you can just test or at least not easily

> [!NOTE]
> *POST-MERGE ACTION*
> Fix up the `release/v.1.1x` branch so it is based off the latest changes (this commit) so theres no workflow mismatch confusion and the backport prs dont cause any unexpected changes
