### PR TITLE
refactor: use a new `Section` component across all sections

### DIFF
--- a/src/app/(frontend)/sponsors/page.tsx
+++ b/src/app/(frontend)/sponsors/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
-import { Container, Heading, LazyImage } from "@/components/Primitive"
+import { Section } from "@/components/Generic"
+import { Container, LazyImage } from "@/components/Primitive"
 import { payload, Slugs } from "@/lib/payload"
 import { cn } from "@/lib/utils"
 import type { Sponsor } from "@/payload/payload-types"
@@ -41,15 +42,11 @@ export default async function SponsorsPage() {
   }
 
   return (
-    <>
-      <div className="flex flex-col items-center gap-3 px-4 text-center md:gap-6">
-        <Heading h={1} period>
-          Our Sponsors
-        </Heading>
-        <p className="paragraph text-gray-700">
-          These are the people that support us and make this club possible.
-        </p>
-      </div>
+    <Section
+      subtitle="These are the people that support us and make this club possible."
+      title="Our Sponsors"
+      titleProps={{ h: 1, period: true }}
+    >
       <div className="flex w-full max-w-220 flex-col items-stretch justify-between gap-x-6 gap-y-12 md:flex-row md:flex-wrap">
         {tiers.map((tier) => (
           <Container
@@ -106,6 +103,6 @@ export default async function SponsorsPage() {
           outreach@uoacs.co.nz
         </a>
       </p>
-    </>
+    </Section>
   )
 }

--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { ExecCard } from "@/components/Generic"
-import { BorderButton, Container, Heading, SocialIcon } from "@/components/Primitive"
+import { ExecCard, Section } from "@/components/Generic"
+import { BorderButton, Container, SocialIcon } from "@/components/Primitive"
 import type { Executive } from "@/payload/payload-types"
 import { EXECUTIVE_LEVEL_ORDER, ExecutiveLevel, ExecutiveTeam } from "@/types/enums"
 
@@ -88,15 +88,12 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
 
   return (
     <>
-      <div className="flex w-full flex-col items-center gap-14 md:gap-18">
-        <div className="flex flex-col items-center gap-2 px-4 text-center">
-          <Heading h={1} period>
-            Our Team
-          </Heading>
-          <p className="paragraph text-gray-700">
-            These are the people who make this club possible.
-          </p>
-        </div>
+      <Section
+        // className="gap-14 md:gap-18"
+        subtitle="These are the people who make this club possible."
+        title="Our Team"
+        titleProps={{ h: 1, period: true }}
+      >
         <div className="flex w-full flex-col items-center justify-center gap-12">
           <div className="hidden max-w-200 flex-row flex-wrap items-center justify-center gap-4 md:flex">
             {currentTeams.map((team: string) => (
@@ -128,16 +125,13 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
               ))}
           </div>
         </div>
-      </div>
-      <div className="flex w-full flex-col items-center gap-14 md:gap-18">
-        <div className="flex flex-col items-center gap-2 px-4 text-center">
-          <div className="relative">
-            <Heading h={1} period>
-              Past Executives
-            </Heading>
-          </div>
-          <p className="paragraph text-gray-700">UOACS Alumni</p>
-        </div>
+      </Section>
+      <Section
+        // className="gap-14 md:gap-18"
+        subtitle="UOACS Alumni"
+        title="Past Executives"
+        titleProps={{ h: 1, period: true }}
+      >
         <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-[4.5rem]">
           {pastTeams.map((team: string) => {
             const execsInTeam = pastExecs.filter((exec: Executive) =>
@@ -173,7 +167,7 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
             )
           })}
         </div>
-      </div>
+      </Section>
     </>
   )
 }

--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -89,7 +89,6 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
   return (
     <>
       <Section
-        // className="gap-14 md:gap-18"
         subtitle="These are the people who make this club possible."
         title="Our Team"
         titleProps={{ h: 1, period: true }}
@@ -126,12 +125,7 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
           </div>
         </div>
       </Section>
-      <Section
-        // className="gap-14 md:gap-18"
-        subtitle="UOACS Alumni"
-        title="Past Executives"
-        titleProps={{ h: 1, period: true }}
-      >
+      <Section subtitle="UOACS Alumni" title="Past Executives" titleProps={{ h: 1, period: true }}>
         <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-[4.5rem]">
           {pastTeams.map((team: string) => {
             const execsInTeam = pastExecs.filter((exec: Executive) =>

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -1,7 +1,7 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
-import { SponsorTicker } from "@/components/Generic"
-import { Button, Heading, LazyImage } from "@/components/Primitive"
+import { Section, SponsorTicker } from "@/components/Generic"
+import { Button, LazyImage } from "@/components/Primitive"
 import { TIER_SIZES } from "@/lib/constants"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
@@ -40,16 +40,17 @@ const ColourPalette = ({ className }: { className: string }) => {
  */
 export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
   return (
-    <div className="flex max-w-360 flex-col items-center justify-center gap-6 overflow-hidden md:gap-12">
-      <div className="relative flex flex-col items-center gap-6 px-4 pt-12 pb-6 text-center md:py-12">
-        <ColourPalette className="top-0 right-0" />
-        <Heading h={2}>Sponsored By</Heading>
-        <p className="paragraph">
-          These are the people that support us and make this club{" "}
-          <span className="text-brand-pink">possible</span>
-        </p>
-        <ColourPalette className="bottom-0 left-0 hidden md:grid" />
-      </div>
+    <Section
+      className="max-w-360 overflow-hidden"
+      subtitle="These are the people that support us and make this club possible."
+      title="Sponsored By"
+      titleOverlay={
+        <>
+          <ColourPalette className="-top-12 right-0" />
+          <ColourPalette className="top-full left-0 mt-6 hidden md:grid" />
+        </>
+      }
+    >
       {sponsors.length > 2 ? (
         <SponsorTicker containerClassName="max-w-360" items={sponsors} />
       ) : (
@@ -88,6 +89,6 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
           See All Our Sponsors
         </Button>
       </Link>
-    </div>
+    </Section>
   )
 }

--- a/src/components/Composite/SponsorsSection/SponsorsSection.tsx
+++ b/src/components/Composite/SponsorsSection/SponsorsSection.tsx
@@ -42,12 +42,18 @@ export const SponsorsSection = ({ sponsors }: SponsorsSectionProps) => {
   return (
     <Section
       className="max-w-360 overflow-hidden"
-      subtitle="These are the people that support us and make this club possible."
+      headerClassName="pt-12 pb-6 md:py-12"
+      subtitle={
+        <>
+          These are the people that support us and make this club{" "}
+          <span className="text-brand-pink">possible</span>
+        </>
+      }
       title="Sponsored By"
       titleOverlay={
         <>
-          <ColourPalette className="-top-12 right-0" />
-          <ColourPalette className="top-full left-0 mt-6 hidden md:grid" />
+          <ColourPalette className="top-0 right-0" />
+          <ColourPalette className="bottom-0 left-0 hidden md:grid" />
         </>
       }
     >

--- a/src/components/Composite/ValuesSection/ValuesSection.tsx
+++ b/src/components/Composite/ValuesSection/ValuesSection.tsx
@@ -1,25 +1,23 @@
 import Image from "next/image"
-import { ValuesAccordion } from "@/components/Generic"
-import { Heading } from "@/components/Primitive"
+import { Section, ValuesAccordion } from "@/components/Generic"
 import { VALUES } from "./ValuesSection.constants"
 
 export const ValuesSection = () => {
   return (
-    <div className="flex w-full flex-col items-center justify-center gap-10 md:gap-22">
-      <div className="flex flex-col items-center justify-center gap-4 text-center">
-        <div className="relative flex justify-center">
-          <Heading h={2}>Our Values</Heading>
-          <Image
-            alt="react fragment"
-            className="absolute top-0 right-0 h-12 w-12 translate-x-full -translate-y-1/2 md:h-16 md:w-16"
-            height={75}
-            src="/react-fragment.svg"
-            width={75}
-          />
-        </div>
-        <p className="paragraph">These principles guide our behaviors and who we are</p>
-      </div>
+    <Section
+      subtitle="These principles guide our behaviors and who we are"
+      title="Our Values"
+      titleOverlay={
+        <Image
+          alt="react fragment"
+          className="absolute top-0 right-0 h-12 w-12 translate-x-full -translate-y-1/2 md:h-16 md:w-16"
+          height={75}
+          src="/react-fragment.svg"
+          width={75}
+        />
+      }
+    >
       <ValuesAccordion values={VALUES} />
-    </div>
+    </Section>
   )
 }

--- a/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
+++ b/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
-import { Polaroid } from "@/components/Generic"
+import { Polaroid, Section } from "@/components/Generic"
 import { Heading } from "@/components/Primitive"
 import type { Polaroid as PolaroidType } from "@/payload/payload-types"
 
@@ -47,15 +47,10 @@ export const WhoWeAreSection = ({ polaroids }: WhoWeAreSectionProps) => {
   }, [])
 
   return (
-    <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
-      <div className="flex max-w-lg flex-col items-center gap-4 text-center">
-        <Heading h={2}>Who We Are</Heading>
-        <p className="paragraph">
-          As well as being a social club, we also help out newer students through workshops and run
-          industry related events to connect you with real companies.
-        </p>
-      </div>
-
+    <Section
+      subtitle="As well as being a social club, we also help out newer students through workshops and run industry related events to connect you with real companies."
+      title="Who We Are"
+    >
       <div className="flex w-full flex-wrap justify-center gap-12">
         <div className="flex w-full max-w-md flex-col gap-4 md:w-auto">
           <div className="flex min-h-36 flex-col gap-2 bg-accent-purple-light p-4">
@@ -130,6 +125,6 @@ export const WhoWeAreSection = ({ polaroids }: WhoWeAreSectionProps) => {
           </div>
         </div>
       </div>
-    </div>
+    </Section>
   )
 }

--- a/src/components/Generic/Section/Section.stories.tsx
+++ b/src/components/Generic/Section/Section.stories.tsx
@@ -29,6 +29,6 @@ export const WithoutSubtitle: Story = {
 
 export const WithTitleOverlay: Story = {
   args: {
-    titleOverlay: <span className="-right-6 -top-2 absolute text-xs text-accent-yellow">New</span>,
+    titleOverlay: <span className="absolute -top-2 -right-6 text-accent-yellow text-xs">New</span>,
   },
 }

--- a/src/components/Generic/Section/Section.stories.tsx
+++ b/src/components/Generic/Section/Section.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+import { Section } from "./Section"
+
+const meta: Meta<typeof Section> = {
+  title: "Generic Components/Section",
+  component: Section,
+  argTypes: {
+    title: { control: "text" },
+    subtitle: { control: "text" },
+  },
+  args: {
+    title: "Our Team",
+    subtitle: "These are the people who make this club possible.",
+    children: <div className="h-32 w-full rounded-md bg-gray-100" />,
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Section>
+
+export const Basic: Story = {}
+
+export const WithoutSubtitle: Story = {
+  args: {
+    subtitle: undefined,
+  },
+}
+
+export const WithTitleOverlay: Story = {
+  args: {
+    titleOverlay: <span className="-right-6 -top-2 absolute text-xs text-accent-yellow">New</span>,
+  },
+}

--- a/src/components/Generic/Section/Section.tsx
+++ b/src/components/Generic/Section/Section.tsx
@@ -43,24 +43,3 @@ export const Section = ({
     </section>
   )
 }
-
-/**
- * <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
-      <div className="flex max-w-lg flex-col items-center gap-4 text-center">
-        <Heading h={2}>Who We Are</Heading>
-        <p className="paragraph">
-          As well as being a social club, we also help out newer students through workshops and run
-          industry related events to connect you with real companies.
-        </p>
-      </div>
-
-  <div className="flex w-full flex-col items-center gap-14 md:gap-18">
-        <div className="flex flex-col items-center gap-2 px-4 text-center">
-          <Heading h={1} period>
-            Our Team
-          </Heading>
-          <p className="paragraph text-gray-700">
-            These are the people who make this club possible.
-          </p>
-        </div>
- */

--- a/src/components/Generic/Section/Section.tsx
+++ b/src/components/Generic/Section/Section.tsx
@@ -1,0 +1,66 @@
+import { Heading, type HeadingProps } from "@/components/Primitive"
+import { cn } from "@/lib/utils"
+
+export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
+  title: string
+  titleProps?: Omit<HeadingProps, "children">
+  titleOverlay?: React.ReactNode
+  subtitle?: string
+  subtitleClassName?: string
+  children: React.ReactNode
+}
+
+export const Section = ({
+  title,
+  titleProps,
+  titleOverlay,
+  subtitle,
+  subtitleClassName,
+  children,
+  className,
+  ...rest
+}: SectionProps) => {
+  return (
+    <section className={cn("flex w-full flex-col items-center gap-10", className)} {...rest}>
+      <div className="flex flex-col items-center gap-2 px-4 text-center">
+        {titleOverlay ? (
+          <div className="relative flex justify-center">
+            <Heading h={2} {...titleProps}>
+              {title}
+            </Heading>
+            {titleOverlay}
+          </div>
+        ) : (
+          <Heading h={2} {...titleProps}>
+            {title}
+          </Heading>
+        )}
+        {subtitle && (
+          <p className={cn("paragraph max-w-lg text-gray-700", subtitleClassName)}>{subtitle}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+/**
+ * <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
+      <div className="flex max-w-lg flex-col items-center gap-4 text-center">
+        <Heading h={2}>Who We Are</Heading>
+        <p className="paragraph">
+          As well as being a social club, we also help out newer students through workshops and run
+          industry related events to connect you with real companies.
+        </p>
+      </div>
+
+  <div className="flex w-full flex-col items-center gap-14 md:gap-18">
+        <div className="flex flex-col items-center gap-2 px-4 text-center">
+          <Heading h={1} period>
+            Our Team
+          </Heading>
+          <p className="paragraph text-gray-700">
+            These are the people who make this club possible.
+          </p>
+        </div>
+ */

--- a/src/components/Generic/Section/Section.tsx
+++ b/src/components/Generic/Section/Section.tsx
@@ -5,7 +5,8 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
   title: string
   titleProps?: Omit<HeadingProps, "children">
   titleOverlay?: React.ReactNode
-  subtitle?: string
+  headerClassName?: string
+  subtitle?: React.ReactNode
   subtitleClassName?: string
   children: React.ReactNode
 }
@@ -14,31 +15,28 @@ export function Section({
   title,
   titleProps,
   titleOverlay,
+  headerClassName,
   subtitle,
   subtitleClassName,
   children,
   className,
   ...rest
 }: SectionProps) {
-  const heading = (
-    <Heading h={2} {...titleProps}>
-      {title}
-    </Heading>
-  )
-
   return (
     <section className={cn("flex w-full flex-col items-center gap-10", className)} {...rest}>
-      <div className="flex flex-col items-center gap-2 px-4 text-center">
-        {titleOverlay ? (
-          <div className="relative flex justify-center">
-            {heading}
-            {titleOverlay}
-          </div>
-        ) : (
-          heading
+      <div
+        className={cn(
+          "flex flex-col items-center gap-2 px-4 text-center",
+          titleOverlay && "relative",
+          headerClassName,
         )}
+      >
+        <Heading h={2} {...titleProps}>
+          {title}
+        </Heading>
+        {titleOverlay}
         {subtitle && (
-          <p className={cn("paragraph max-w-lg text-gray-700", subtitleClassName)}>{subtitle}</p>
+          <p className={cn("paragraph max-w-xl text-gray-700", subtitleClassName)}>{subtitle}</p>
         )}
       </div>
       {children}

--- a/src/components/Generic/Section/Section.tsx
+++ b/src/components/Generic/Section/Section.tsx
@@ -10,7 +10,7 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode
 }
 
-export const Section = ({
+export function Section({
   title,
   titleProps,
   titleOverlay,
@@ -19,21 +19,23 @@ export const Section = ({
   children,
   className,
   ...rest
-}: SectionProps) => {
+}: SectionProps) {
+  const heading = (
+    <Heading h={2} {...titleProps}>
+      {title}
+    </Heading>
+  )
+
   return (
     <section className={cn("flex w-full flex-col items-center gap-10", className)} {...rest}>
       <div className="flex flex-col items-center gap-2 px-4 text-center">
         {titleOverlay ? (
           <div className="relative flex justify-center">
-            <Heading h={2} {...titleProps}>
-              {title}
-            </Heading>
+            {heading}
             {titleOverlay}
           </div>
         ) : (
-          <Heading h={2} {...titleProps}>
-            {title}
-          </Heading>
+          heading
         )}
         {subtitle && (
           <p className={cn("paragraph max-w-lg text-gray-700", subtitleClassName)}>{subtitle}</p>

--- a/src/components/Generic/index.ts
+++ b/src/components/Generic/index.ts
@@ -1,5 +1,6 @@
 export * from "./ExecCard/ExecCard"
 export * from "./Polaroid/Polaroid"
+export * from "./Section/Section"
 export * from "./SocialLinks/SocialLinks"
 export * from "./SponsorBadge/SponsorBadge"
 export * from "./SponsorTicker/SponsorTicker"


### PR DESCRIPTION
# Description
This PR introduces a `Section` generic component and refactors existing composite components and pages to use it in place of inline section headers.

- adds `Section` to `src/components/Generic/` with support for `title`, `subtitle`, `titleProps`, `titleOverlay`, `headerClassName`, and `subtitleClassName`
- adds Storybook stories for `Section`
- exports `Section` from `src/components/Generic/index.ts`
- replaces inline section header markup in `SponsorsSection`, `ValuesSection`, `WhoWeAreSection`, `TeamPageClient`, and the sponsors page with the `Section` component

Not related to a ticket

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member