### PR TITLE
fix(polaroid): use full image styles to rid warnings

### DIFF
--- a/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
+++ b/src/components/Composite/WhoWeAreSection/WhoWeAreSection.tsx
@@ -117,8 +117,8 @@ export const WhoWeAreSection = ({ polaroids }: WhoWeAreSectionProps) => {
                   rotation={preset.rotation}
                   text={polaroid.caption}
                   url={src}
-                  x_offset={preset.x}
-                  y_offset={preset.y}
+                  xOffset={preset.x}
+                  yOffset={preset.y}
                 />
               )
             })}

--- a/src/components/Generic/Polaroid/Polaroid.stories.tsx
+++ b/src/components/Generic/Polaroid/Polaroid.stories.tsx
@@ -7,15 +7,15 @@ const meta: Meta<typeof Polaroid> = {
   argTypes: {
     text: { control: "text" },
     url: { control: "text" },
-    x_offset: { control: "number" },
-    y_offset: { control: "number" },
+    xOffset: { control: "number" },
+    yOffset: { control: "number" },
     rotation: { control: "number" },
   },
   args: {
     text: "Pool Night",
     url: "media/Pool.jpeg",
-    x_offset: 50,
-    y_offset: 50,
+    xOffset: 50,
+    yOffset: 50,
     rotation: 0,
   },
 }
@@ -33,8 +33,8 @@ export const Multiple: Story = (args) => {
         {...{
           text: "Pool Night 2 electric Bogaloo",
           url: "/media/Pool.jpeg",
-          x_offset: 400,
-          y_offset: 110,
+          xOffset: 400,
+          yOffset: 110,
           rotation: 12,
         }}
       />
@@ -42,8 +42,8 @@ export const Multiple: Story = (args) => {
         {...{
           text: "JoshLi because thats only other image here",
           url: "/media/JoshLi.jpeg",
-          x_offset: 700,
-          y_offset: 160,
+          xOffset: 700,
+          yOffset: 160,
           rotation: 45,
         }}
       />

--- a/src/components/Generic/Polaroid/Polaroid.tsx
+++ b/src/components/Generic/Polaroid/Polaroid.tsx
@@ -17,71 +17,66 @@ export interface PolaroidProps {
   /**
    * Offset from left edge of parent element
    */
-  x_offset: number
+  xOffset: number
   /**
    * Offset from top edge of parent element
    */
-  y_offset: number
+  yOffset: number
   /**
    * Rotation in degrees between 0 and 360
    */
   rotation: number
 }
 
-export const Polaroid = ({
-  text,
-  url,
-  x_offset = 0,
-  y_offset = 0,
-  rotation = 0,
-}: PolaroidProps) => {
+export const Polaroid = ({ text, url, xOffset = 0, yOffset = 0, rotation = 0 }: PolaroidProps) => {
   // Math for transforming Image
-  const rotrad = (rotation / 180) * Math.PI
-  const image_width: number =
-    Math.abs(IMAGE_WIDTH * Math.cos(rotrad)) + Math.abs(IMAGE_HEIGHT * Math.sin(rotrad))
-  const scale_factor = (image_width / IMAGE_WIDTH) * 0.91
-  const image_center = PADDING + IMAGE_HEIGHT / 2
-  const rotation_offset = POLAROID_HEIGHT / 2 - image_center
-  const x_translate = rotation_offset
+  const rotationRadians = (rotation / 180) * Math.PI
+  const imageWidth: number =
+    Math.abs(IMAGE_WIDTH * Math.cos(rotationRadians)) +
+    Math.abs(IMAGE_HEIGHT * Math.sin(rotationRadians))
+  const scaleFactor = (imageWidth / IMAGE_WIDTH) * 0.91
+  const imageCenter = PADDING + IMAGE_HEIGHT / 2
+  const rotationOffset = POLAROID_HEIGHT / 2 - imageCenter
+  const xTranslate = rotationOffset
 
   // Styles applied from Math
-  const transform_styles = {
-    left: `${x_offset}px`,
-    top: `${y_offset}px`,
+  const transformStyles = {
+    left: `${xOffset}px`,
+    top: `${yOffset}px`,
     rotate: `${rotation}deg`,
     height: `${POLAROID_HEIGHT}px`,
     padding: PADDING,
   }
-  const reverse_rot = {
-    transform: `translate(0,${-x_translate}px ) rotate(-${rotation}deg) scale(${scale_factor})`,
+  const reverseRotation = {
+    transform: `translate(0,${-xTranslate}px ) rotate(-${rotation}deg) scale(${scaleFactor})`,
   }
-  const mask_image_styles = {
+  const maskImageStyles = {
     clipPath: `rect(0px ${IMAGE_WIDTH}px ${IMAGE_HEIGHT}px 0px round 1%)`,
     width: IMAGE_WIDTH,
     height: IMAGE_HEIGHT,
   }
-  const image_styles = {
+  const imageStyles = {
     position: "absolute" as const,
     top: 0,
     left: 0,
     width: "100%",
     height: "100%",
-    ...reverse_rot,
+    ...reverseRotation,
   }
 
   return (
     <div
       className="absolute inline-flex flex-col items-center gap-3 rounded-sm bg-white shadow-lg"
-      style={transform_styles}
+      style={transformStyles}
     >
-      <div style={mask_image_styles}>
+      <div style={maskImageStyles}>
         <Image
           alt="Photo of event"
           className="object-cover"
           height={POLAROID_HEIGHT}
           sizes={`${IMAGE_WIDTH}px`}
           src={url}
-          style={image_styles}
+          style={imageStyles}
           width={IMAGE_WIDTH + 2 * PADDING}
         />
       </div>

--- a/src/components/Generic/Polaroid/Polaroid.tsx
+++ b/src/components/Generic/Polaroid/Polaroid.tsx
@@ -60,6 +60,14 @@ export const Polaroid = ({
     width: IMAGE_WIDTH,
     height: IMAGE_HEIGHT,
   }
+  const image_styles = {
+    position: "absolute" as const,
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    ...reverse_rot,
+  }
 
   return (
     <div
@@ -67,7 +75,15 @@ export const Polaroid = ({
       style={transform_styles}
     >
       <div style={mask_image_styles}>
-        <Image alt="Photo of event" className="object-cover" fill src={url} style={reverse_rot} />
+        <Image
+          alt="Photo of event"
+          className="object-cover"
+          height={POLAROID_HEIGHT}
+          sizes={`${IMAGE_WIDTH}px`}
+          src={url}
+          style={image_styles}
+          width={IMAGE_WIDTH + 2 * PADDING}
+        />
       </div>
       <p className="paragraph-xs w-full text-left font-mono">{text.toUpperCase()}</p>
     </div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

We were getting lots of warning logs in dev:
```
[browser] Image with src "/payload/api/media/file/Pool-1.jpeg" has "fill" but is missing "sizes" prop. Please add it to improve page performance. Read more: https://nextjs.org/docs/api-reference/next/image#sizes
[browser] Image with src "/payload/api/media/file/Pool-1.jpeg" has "fill" and parent element with invalid "position". Provided "static" should be one of absolute,fixed,relative.
[browser] Image with src "/payload/api/media/file/uoacs-electives-154-3.webp" has "fill" but is missing "sizes" prop. Please add it to improve page performance. Read more: https://nextjs.org/docs/api-reference/next/image#sizes
[browser] Image with src "/payload/api/media/file/uoacs-electives-154-3.webp" has "fill" and parent element with invalid "position". Provided "static" should be one of absolute,fixed,relative.
[browser] Image with src "/payload/api/media/file/hackathon-2025-edited-117.jpg" has "fill" but is missing "sizes" prop. Please add it to improve page performance. Read more: https://nextjs.org/docs/api-reference/next/image#sizes
[browser] Image with src "/payload/api/media/file/hackathon-2025-edited-117.jpg" has "fill" and parent element with invalid "position". Provided "static" should be one of absolute,fixed,relative.
```

So I basically fixed these with the following:
- fixes Next.js warnings by replacing `fill` with explicit `width`, `height`, and `sizes` props on the `Image` component in `Polaroid.tsx`
- adds an `imageStyles` object to apply absolute positioning and reverse rotation transforms directly via `style`, replacing the previous `fill`-based approach

Then I realised that Rick used snake_case, so I renamed all the variables to be camelCase for codebase consistency.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
