### PR TITLE
plan(auth): add gsd plan for implementing auth

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,71 @@
+# Better Auth + Member Authentication
+
+## What This Is
+
+Member authentication for the UOACS website. Club members can currently sign up via `/sign-up` but have no way to log back in. This milestone adds Better Auth (standalone, MongoDB) for member-facing auth, renames the Payload `User` collection to `Admin` to clearly separate concerns, and rebuilds the sign-up flow as a multi-step wizard that handles both new members and existing members claiming their account.
+
+## Core Value
+
+Club members can log in to the website using the email they signed up with — and existing members can claim their account without creating a duplicate membership.
+
+## Requirements
+
+### Validated
+
+- ✓ Member sign-up via `/sign-up` (single-page form) — existing
+- ✓ Payload CMS admin panel at `/payload/admin` with built-in User auth — existing
+- ✓ Member, Executive, Sponsor, Reel, Polaroid, Media collections in Payload — existing
+- ✓ Public frontend routes (all unauthenticated) — existing
+- ✓ ISR cache invalidation via Payload afterChange hooks — existing
+
+### Active
+
+- [ ] Rename Payload `User` collection → `Admin` (slug: `admin`, `dbName: "users"` to preserve existing data)
+- [ ] Install Better Auth + direct `mongodb` dependency
+- [ ] Better Auth server config (`src/lib/auth.ts`) — MongoDB adapter, same DB as Payload
+- [ ] Shared MongoClient instance (`src/lib/mongo.ts`) for Better Auth
+- [ ] Better Auth React client (`src/lib/auth-client.ts`)
+- [ ] Better Auth API catch-all route (`src/app/api/auth/[...all]/route.ts`)
+- [ ] Add `betterAuthUserId` field to Member collection (nullable, unique)
+- [ ] Multi-step sign-up wizard: Step 1 (email) → membership lookup → Step 2 (member fields, new only) → Step 3 (password)
+- [ ] "No match" prompt on sign-up: "Already a member? Contact the committee to link your account."
+- [ ] Updated sign-up API route: create Better Auth user + Payload Member atomically; delete BA user + return 500 on Member creation failure
+- [ ] Login page (`/login`) with `LoginForm` — email + password, redirect to home on success
+- [ ] Session-aware navbar: show Login link when logged out, display name + Logout when logged in
+- [ ] Scaffold `src/middleware.ts` with empty matcher
+
+### Out of Scope
+
+- Gated/protected routes — middleware is scaffolded but matcher is empty; route protection is a future milestone
+- OAuth / social login — email + password sufficient for v1
+- Student ID as a membership lookup key — too error-prone (easy to misspell, no uniqueness guarantee)
+- Retroactive account linking for existing members who used a different email — edge case handled operationally by committee
+
+## Context
+
+- **Stack:** Next.js 16 (App Router), Payload CMS 3.80 (MongoDB), TypeScript, Tailwind CSS, react-hook-form + Zod, Sonner toasts
+- **Database:** Single MongoDB instance shared by Payload and Better Auth. Better Auth creates its own collections (`user`, `session`, `account`, `verification`) alongside Payload's collections.
+- **Admin data preservation:** `User` → `Admin` rename uses `dbName: "users"` so the underlying MongoDB collection stays `users` — no migration needed.
+- **Sign-up wizard logic:** Step 1 checks Member collection by email. If match found → skip member fields, link existing Member to new Better Auth user. If no match → full member form flow. Sign-up API creates both records; on Payload failure it deletes the Better Auth user before returning 500.
+- **Form patterns:** Follow existing `SignUpForm` conventions — react-hook-form + Zod resolver, Primitive `Input` components, Sonner toast on success/error.
+
+## Constraints
+
+- **Tech stack:** Better Auth must use the same MongoDB instance (no separate DB or connection string)
+- **Data compatibility:** Admin collection rename must not require a MongoDB migration — use `dbName: "users"`
+- **Rollback:** If Member creation fails after Better Auth user is created, call `auth.api.deleteUser()` and return 500 — no silent orphans
+- **Existing members:** Email is the only reliable lookup key — no student ID lookup
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Better Auth shares Payload's MongoDB DB | Single connection string, simpler ops | — Pending |
+| `dbName: "users"` on Admin collection | Avoids one-time MongoDB migration for existing admin records | — Pending |
+| Email lookup for membership claim | Only reliable unique identifier; student ID too error-prone | — Pending |
+| Multi-step sign-up wizard | Existing vs new member paths diverge after email entry | — Pending |
+| Delete BA user on Member creation failure | No silent orphans; atomic UX from member's perspective | — Pending |
+| Session-aware navbar (name + Logout) | Immediate feedback that auth is working | — Pending |
+
+---
+*Last updated: 2026-04-02 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,104 @@
+# Requirements: Better Auth + Member Authentication
+
+**Defined:** 2026-04-02
+**Core Value:** Club members can log in to the website using the email they signed up with — and existing members can claim their account without creating a duplicate membership.
+
+## v1 Requirements
+
+### Infrastructure
+
+- [ ] **INFRA-01**: Rename Payload `User` collection to `Admin` (slug: `admin`, `dbName: "users"` to preserve existing MongoDB data)
+- [ ] **INFRA-02**: Install `better-auth` and `mongodb` as direct dependencies
+- [ ] **INFRA-03**: Shared `MongoClient` instance exported from `src/lib/mongo.ts` for use by Better Auth
+- [ ] **INFRA-04**: Better Auth server config at `src/lib/auth.ts` — MongoDB adapter, email+password enabled, same DB as Payload
+- [ ] **INFRA-05**: Better Auth React client at `src/lib/auth-client.ts`
+- [ ] **INFRA-06**: Better Auth API catch-all route at `src/app/api/auth/[...all]/route.ts`
+- [ ] **INFRA-07**: Middleware scaffolded at `src/middleware.ts` with empty matcher (no route protection yet)
+
+### Member Collection
+
+- [ ] **MEMB-01**: Add nullable `betterAuthUserId` text field to Member collection (unique, readOnly in admin)
+
+### Sign-Up Flow
+
+- [ ] **SGUP-01**: Sign-up wizard Step 1 — user enters email; system checks Member collection for a match
+- [ ] **SGUP-02**: Sign-up wizard Step 2 (new members only) — member profile fields (name, student number, degree, etc.)
+- [ ] **SGUP-03**: Sign-up wizard Step 3 — password and confirm password entry (min 8 chars, must match)
+- [ ] **SGUP-04**: "No match" prompt displayed when email not found — "Already a member? Contact the committee to link your account." with option to proceed as new member
+- [ ] **SGUP-05**: Sign-up API creates Better Auth user + new Payload Member atomically for new members
+- [ ] **SGUP-06**: Sign-up API links existing Member (`betterAuthUserId`) when email matches existing record — skips Member creation
+- [ ] **SGUP-07**: Sign-up API deletes Better Auth user and returns 500 if Payload Member creation fails (no silent orphans)
+
+### Login
+
+- [ ] **AUTH-01**: Login page at `/login` with email + password form (react-hook-form + Zod, follows SignUpForm patterns)
+- [ ] **AUTH-02**: Successful login redirects to home
+- [ ] **AUTH-03**: `Routes.LOGIN = "/login"` added to `src/lib/routes.ts`
+
+### Navigation
+
+- [ ] **NAV-01**: Navbar shows "Login" link when user is not authenticated
+- [ ] **NAV-02**: Navbar shows display name + "Logout" button when user is authenticated
+- [ ] **NAV-03**: Logout clears Better Auth session and redirects to home
+
+## v2 Requirements
+
+### Route Protection
+
+- **PROT-01**: Middleware checks Better Auth session cookie and redirects unauthenticated users from protected routes
+- **PROT-02**: Members-only area (profile page or dashboard) gated behind authentication
+
+### Account Management
+
+- **ACCT-01**: Member can change their password
+- **ACCT-02**: Member can update their email address
+- **ACCT-03**: Email verification flow after sign-up
+
+### Admin Tools
+
+- **ADMIN-01**: Committee can manually link a Better Auth user to an existing Member record (for edge cases where emails don't match)
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| OAuth / social login | Email + password sufficient for v1 |
+| Student ID as membership lookup key | No uniqueness guarantee, easy to misspell |
+| Email verification on sign-up | Adds friction; v2 when route protection needs it |
+| Role-based access control | No protected routes in this milestone |
+| Mobile app / push notifications | Web-first |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| INFRA-01 | Phase 1 | Pending |
+| INFRA-02 | Phase 1 | Pending |
+| INFRA-03 | Phase 1 | Pending |
+| INFRA-04 | Phase 1 | Pending |
+| INFRA-05 | Phase 1 | Pending |
+| INFRA-06 | Phase 1 | Pending |
+| INFRA-07 | Phase 1 | Pending |
+| MEMB-01 | Phase 1 | Pending |
+| SGUP-01 | Phase 2 | Pending |
+| SGUP-02 | Phase 2 | Pending |
+| SGUP-03 | Phase 2 | Pending |
+| SGUP-04 | Phase 2 | Pending |
+| SGUP-05 | Phase 2 | Pending |
+| SGUP-06 | Phase 2 | Pending |
+| SGUP-07 | Phase 2 | Pending |
+| AUTH-01 | Phase 3 | Pending |
+| AUTH-02 | Phase 3 | Pending |
+| AUTH-03 | Phase 3 | Pending |
+| NAV-01 | Phase 3 | Pending |
+| NAV-02 | Phase 3 | Pending |
+| NAV-03 | Phase 3 | Pending |
+
+**Coverage:**
+- v1 requirements: 21 total
+- Mapped to phases: 21
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-04-02*
+*Last updated: 2026-04-02 after initial definition*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,65 @@
+# Roadmap: Better Auth + Member Authentication
+
+## Overview
+
+This milestone adds member-facing authentication to the UOACS website. Phase 1 lays the foundation — renaming the Payload User collection, wiring up Better Auth, and updating the Member data model. Phase 2 replaces the single-page sign-up form with a multi-step wizard that handles both new members and existing members claiming their account. Phase 3 delivers the login page and a session-aware navbar so members can see their authenticated state from every page.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [ ] **Phase 1: Foundation** - Rename Admin collection, install Better Auth, wire up shared MongoDB client and lib files, scaffold middleware
+- [ ] **Phase 2: Sign-Up Flow** - Multi-step wizard that handles new members and existing member account claiming
+- [ ] **Phase 3: Login + Navigation** - Login page and session-aware navbar
+
+## Phase Details
+
+### Phase 1: Foundation
+**Goal**: Better Auth is installed and configured; the Admin/User collection rename is complete; all shared infrastructure files exist and the app still runs
+**Depends on**: Nothing (first phase)
+**Requirements**: INFRA-01, INFRA-02, INFRA-03, INFRA-04, INFRA-05, INFRA-06, INFRA-07, MEMB-01
+**Success Criteria** (what must be TRUE):
+  1. Payload admin panel loads at `/payload/admin` and existing admin accounts still work (collection rename did not destroy data)
+  2. Better Auth API route responds at `/api/auth/*` — a request to the health or session endpoint returns a valid response
+  3. `src/lib/auth.ts`, `src/lib/auth-client.ts`, and `src/lib/mongo.ts` exist with no TypeScript errors
+  4. Member collection has a `betterAuthUserId` field visible (read-only) in the Payload admin
+  5. `src/middleware.ts` exists with an empty matcher and does not break any existing routes
+**Plans**: TBD
+
+### Phase 2: Sign-Up Flow
+**Goal**: Members can complete registration through a multi-step wizard — new members create a full profile, existing members claim their account by email
+**Depends on**: Phase 1
+**Requirements**: SGUP-01, SGUP-02, SGUP-03, SGUP-04, SGUP-05, SGUP-06, SGUP-07
+**Success Criteria** (what must be TRUE):
+  1. A new member can enter their email, fill in their profile, set a password, and end up with both a Better Auth user and a Payload Member record linked by `betterAuthUserId`
+  2. An existing member enters their email, skips the profile step, sets a password, and has their existing Member record updated with the new `betterAuthUserId`
+  3. When an email has no match, the wizard shows the "Already a member? Contact the committee" prompt and still lets the user proceed as a new member
+  4. If the Payload Member creation fails after the Better Auth user is created, the Better Auth user is deleted and a 500 is returned — no orphaned auth records exist
+**Plans**: TBD
+
+### Phase 3: Login + Navigation
+**Goal**: Members can log in with email and password and see their authenticated state reflected in the navbar from every page
+**Depends on**: Phase 2
+**Requirements**: AUTH-01, AUTH-02, AUTH-03, NAV-01, NAV-02, NAV-03
+**Success Criteria** (what must be TRUE):
+  1. A member can visit `/login`, enter their email and password, and be redirected to the home page on success
+  2. An incorrect password or unknown email shows a visible error — the member is not redirected
+  3. When logged out, the navbar shows a "Login" link pointing to `/login`
+  4. When logged in, the navbar shows the member's display name and a "Logout" button
+  5. Clicking "Logout" clears the session and returns the member to the home page with the navbar back in logged-out state
+**Plans**: TBD
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Foundation | 0/? | Not started | - |
+| 2. Sign-Up Flow | 0/? | Not started | - |
+| 3. Login + Navigation | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,62 @@
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-02)
+
+**Core value:** Club members can log in to the website using the email they signed up with — and existing members can claim their account without creating a duplicate membership.
+**Current focus:** Phase 1 — Foundation
+
+## Current Position
+
+Phase: 1 of 3 (Foundation)
+Plan: 0 of ? in current phase
+Status: Ready to plan
+Last activity: 2026-04-02 — Roadmap created
+
+Progress: [░░░░░░░░░░] 0%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: -
+- Total execution time: -
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+**Recent Trend:**
+- Last 5 plans: -
+- Trend: -
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Foundation: `dbName: "users"` on Admin collection avoids MongoDB migration for existing admin records
+- Foundation: Better Auth shares Payload's MongoDB DB — single connection string
+- Sign-Up: Email is the only lookup key for membership claim (student ID too error-prone)
+- Sign-Up: Delete BA user on Member creation failure — no silent orphans
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+None yet.
+
+## Session Continuity
+
+Last session: 2026-04-02
+Stopped at: Roadmap written, STATE.md initialized — ready to plan Phase 1
+Resume file: None

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,203 @@
+# Architecture
+
+**Analysis Date:** 2026-04-02
+
+## Pattern Overview
+
+**Overall:** Headless CMS with Next.js frontend - Component-based UI layer with Payload CMS providing data and content management.
+
+**Key Characteristics:**
+- Server-side rendering (SSR) with React Server Components (RSCs) for data fetching
+- Hybrid client/server rendering strategy
+- Content managed centrally through Payload CMS (MongoDB backend)
+- ISR (Incremental Static Revalidation) for cache invalidation on content changes
+- Component-driven architecture with strict layering (Primitive → Generic → Composite)
+
+## Layers
+
+**Data Layer (CMS & Database):**
+- Purpose: Manages all persistent data and content
+- Location: `src/payload/` and Payload CMS admin interface
+- Contains: Collection definitions (Member, Executive, Sponsor, Reel, Polaroid, Media), global settings (HomePage, PrivacyPolicy, SocialLinks)
+- Depends on: MongoDB (via `@payloadcms/db-mongodb`)
+- Used by: API layer and server components
+
+**API Layer:**
+- Purpose: Provides server-side data access and route handlers
+- Location: `src/app/api/` and `src/lib/payload.ts`
+- Contains: REST endpoints (sign-up, health check) and Payload SDK initialization
+- Depends on: Payload CMS, data validation schemas
+- Used by: Server components, client-side fetch calls
+
+**Component Layer:**
+- Purpose: Renders UI in three abstraction levels
+- Location: `src/components/Primitive/`, `src/components/Generic/`, `src/components/Composite/`
+- Contains: Reusable UI building blocks organized by complexity
+- Depends on: React, Tailwind CSS, type definitions
+- Used by: Page components and higher-level components
+
+**Page/Route Layer:**
+- Purpose: Maps routes to page components and orchestrates data fetching
+- Location: `src/app/(frontend)/` and `src/app/api/`
+- Contains: Server components (async functions) and client entry points
+- Depends on: Component layer, API layer, Payload data
+- Used by: Next.js router
+
+**Configuration & Infrastructure:**
+- Purpose: Initializes Payload CMS, defines collections/globals, and environment setup
+- Location: `src/payload.config.ts`, `.env` variables
+- Contains: Database adapters (MongoDB), storage (S3), plugins, field configurations
+- Depends on: External services (MongoDB, S3, AWS)
+- Used by: Entire application stack
+
+## Data Flow
+
+**Homepage Render Flow:**
+
+1. `src/app/(frontend)/page.tsx` (Server Component) executes
+2. Calls `payload.findGlobal({ slug: HOME_PAGE })` to fetch home content
+3. Calls `getSocialLinks()` helper which queries `SocialLinks` global
+4. Resolves related documents (reels as Reel[], polaroids as Polaroid[])
+5. Passes resolved data as props to section components: `HeroSection`, `AboutUsSection`, `WhoWeAreSection`, `ValuesSection`, `SponsorsServerSection`
+6. Each section component renders with data from Payload
+7. User sees pre-rendered content with server-side data integration
+
+**Sign-Up Flow:**
+
+1. User submits form on `src/app/(frontend)/sign-up/page.tsx`
+2. `SignUpForm` (Client Component) validates with `createMemberSchema` via Zod
+3. POST to `src/app/api/sign-up/route.ts` with form data
+4. Route handler parses/validates with schema, calls `payload.create({ collection: 'member', data })`
+5. On success: revalidates ISR cache, redirects to home, shows success toast
+6. On error: shows error toast (duplicate email = 409, other = generic error)
+7. Payload hook `afterChange` triggers `revalidatePath()` to clear Next.js cache
+
+**Content Update & Cache Invalidation:**
+
+1. Admin updates Executive/Sponsor/HomePage content in Payload CMS
+2. Payload executes `afterChange` or `afterDelete` hook (defined in collection config)
+3. Hook calls `revalidatePath()` for affected routes (e.g., `/team`, `/sponsors`, `/`)
+4. Next.js ISR clears static cache for those paths
+5. Next request to those routes re-renders with fresh data
+
+**State Management:**
+
+- **Server State:** Managed via Payload CMS (source of truth)
+- **Component State:** Local React hooks for UI state (open/closed, form state, loading flags)
+- **Cache Management:** Next.js ISR with Payload-triggered revalidation
+- **Client-side Data:** React hooks (useForm, useState) for transient form/UI state
+
+## Key Abstractions
+
+**Payload Collections:**
+- Purpose: Define data schema and admin UI for each content type
+- Examples: `src/payload/collections/Executive.ts`, `src/payload/collections/Member.ts`, `src/payload/collections/Sponsor.ts`
+- Pattern: CollectionConfig objects with fields, hooks, relationships, and validation logic
+
+**Revalidation Hooks:**
+- Purpose: Trigger ISR cache invalidation when content changes
+- Examples: `makeRevalidateHooks()` in `src/payload/hooks/revalidate.ts`
+- Pattern: Higher-order function returns afterChange/afterDelete/globalAfterChange hooks that call `revalidatePath()`
+
+**Component Hierarchy:**
+- **Primitive:** Basic HTML elements with styling (Button, Input, Radio, Heading, Icons)
+- **Generic:** Composite UI patterns reused across pages (ExecCard, Section, SocialLinks, SponsorBadge, ValuesAccordion)
+- **Composite:** Full page sections and forms (HeroSection, AboutUsSection, SignUpForm, SponsorsSection, WhoWeAreSection)
+
+**Route Configuration:**
+- Purpose: Centralize hardcoded route and API endpoint strings
+- Location: `src/lib/routes.ts`
+- Pattern: Exported const objects (Routes, ApiRoutes) with typed keys
+
+**Slug Management:**
+- Purpose: Centralize collection/global slug definitions to avoid typos
+- Location: `src/lib/slugs.ts`
+- Pattern: Hierarchical object structure (Slugs.Collections.MEMBER, Slugs.Globals.HOME_PAGE)
+
+**Type Generation:**
+- Purpose: Automatically generate TypeScript types from Payload schema
+- Pattern: `src/payload/payload-types.ts` auto-generated during build
+- Usage: Import types like `Executive`, `Member`, `Reel` for type-safe data handling
+
+## Entry Points
+
+**Website (Frontend):**
+- Location: `src/app/(frontend)/layout.tsx`
+- Triggers: Browser navigation to `/`
+- Responsibilities: Sets up root layout with fonts, metadata, navbar/footer, applies global styles
+
+**Sign-Up API:**
+- Location: `src/app/api/sign-up/route.ts`
+- Triggers: POST from client form submission
+- Responsibilities: Validates request, creates Member record, handles errors (duplicate email), returns 201/409
+
+**Health Check:**
+- Location: `src/app/api/health/route.ts`
+- Triggers: External monitoring or deployment checks
+- Responsibilities: Verifies application is running
+
+**Payload Admin:**
+- Location: `src/app/payload/admin/[[...segments]]/page.tsx`
+- Triggers: Access to `/payload/admin`
+- Responsibilities: Serves Payload CMS admin interface
+
+**Payload API:**
+- Location: `src/app/payload/api/[...slug]/route.ts`
+- Triggers: REST requests to `/payload/api/...`
+- Responsibilities: Proxy route for Payload API endpoints
+
+**OG Image Generation:**
+- Location: `src/app/og/route.tsx`
+- Triggers: OpenGraph image requests
+- Responsibilities: Dynamically generates social media preview images
+
+## Error Handling
+
+**Strategy:** Layered error handling with validation at input, graceful degradation in UI, and specific error responses in API routes.
+
+**Patterns:**
+
+- **Validation Errors:** Zod schemas validate at form submission and API route level
+  - Example: `createMemberSchema.parse()` in `src/app/api/sign-up/route.ts` throws on invalid data
+  - Caught and returned as 400/409 responses to client
+
+- **Unique Constraint Errors:** Payload throws `ValidationError` on duplicate emails
+  - Caught in sign-up route handler, returns 409 with error message and field name
+  - Client shows specific toast: "This email is already in use"
+
+- **Server Component Data Fetch Errors:** Propagate up and trigger error boundary
+  - If `payload.find()` fails, error boundary in layout catches and renders error page
+
+- **Missing Data:** Defensive code with optional chaining and nullish coalescing
+  - Example: `(homePage?.reels ?? [])` in `src/app/(frontend)/page.tsx`
+  - Prevents crashes when optional relationships are missing
+
+- **Form Submission Errors:** Try/catch in `onSubmit` with specific error messaging
+  - Network errors and non-201/409 responses trigger generic error toast
+  - 409 errors get specific message about duplicate email
+
+## Cross-Cutting Concerns
+
+**Logging:** 
+- Payload logger used for revalidation tracking: `payload.logger.info(msg)` in hooks
+- Client-side errors logged via toast messages (user-facing, not backend logs)
+
+**Validation:**
+- Zod schemas define all client input contracts
+- Located at: `src/types/schemas/member.ts` (and other schemas)
+- Applied at form submission and API route level
+- Payload field-level validation defined in collection configs (e.g., `validate()` callback in Member.ts)
+
+**Authentication:**
+- No role-based access control for frontend routes (all public)
+- Payload Admin requires auth (handled by Payload CMS built-in auth)
+- Media collection allows read-only public access: `access: { read: () => true }`
+
+**Image Handling:**
+- Sharp image optimization for uploads: `upload.limits.fileSize: 33MB`
+- S3 storage plugin for distributed file storage
+- Media collection with alt text requirements for accessibility
+
+---
+
+*Architecture analysis: 2026-04-02*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,195 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-04-02
+
+## Tech Debt
+
+**Video Compression Revertion:**
+- Issue: Multiple reverts of video compression feature (commit 70f6f26, db7f4d7, 0ae59b7, 3c51828, 60b4716) indicate instability with media processing. Initial attempt caused issues requiring emergency rollback, followed by OOM (Out of Memory) mitigation attempts that still failed.
+- Files: `src/payload/collections/Media.ts`, upload configuration in `src/payload.config.ts`
+- Impact: Media upload feature is disabled. Videos are not compressed before storage, leading to higher bandwidth costs and slower user experience. Original feature development blocked indefinitely.
+- Fix approach: Before reimplementing compression, profile memory usage in production environment (Fly.io). Consider using streaming processor instead of in-memory operations, implement chunked processing, or use dedicated image processing service (Cloudinary, ImageKit).
+
+**Deprecated Component Still in Use:**
+- Issue: `ValuesCarousel` component marked `@deprecated` with instruction to use `ValuesAccordion` instead (line 13-14 of `src/components/Composite/ValuesCarousel/ValuesCarousel.tsx`)
+- Files: `src/components/Composite/ValuesCarousel/ValuesCarousel.tsx`
+- Impact: Creates maintenance burden with two parallel implementations. Future updates need to be applied to both. Increases codebase complexity.
+- Fix approach: Migrate all usages to `ValuesAccordion`, verify visual parity, then delete `ValuesCarousel.tsx` entirely.
+
+**Missing Environment Variables Fallbacks:**
+- Issue: Payload secret and database URI use empty string fallbacks in `src/payload.config.ts` (lines 42, 47)
+  - `secret: process.env.PAYLOAD_SECRET || ""`
+  - `url: process.env.DATABASE_URI || ""`
+- Files: `src/payload.config.ts`
+- Impact: If environment variables are missing, Payload will initialize with invalid/empty configuration. Database connections will silently fail with unclear errors. Secrets configuration will be compromised.
+- Fix approach: Replace empty string fallbacks with explicit error throws. Validate environment at startup using a validation schema (Zod). Log missing required environment variables during build/startup.
+
+## Performance Bottlenecks
+
+**Unoptimized Video Autoplay:**
+- Problem: Multiple `<video>` elements in Reel components use `autoPlay` attribute (`src/components/Composite/Reel/Reel.tsx`, line 38). When multiple reels are visible on carousel, all videos autoplay simultaneously.
+- Files: `src/components/Composite/Reel/Reel.tsx`
+- Cause: No visibility detection or preloading strategy. Browser loads and plays all visible videos immediately.
+- Improvement path: Implement `IntersectionObserver` to only autoplay videos when they enter viewport. Use `loading="lazy"` attribute. Consider using `<picture>` element with poster frames to reduce initial payload.
+
+**Payload Type Generation Large File:**
+- Problem: Generated `src/payload/payload-types.ts` file is 1002 lines. This is an auto-generated file that should not be manually edited.
+- Files: `src/payload/payload-types.ts`
+- Cause: Payload schema complexity. File is re-generated on schema changes.
+- Improvement path: Monitor file size growth. Consider splitting Payload collections into separate type modules if schema becomes more complex. This is a monitoring concern rather than an immediate fix.
+
+**DOM Event Listeners in Multiple Components:**
+- Problem: Global `document.addEventListener("mousedown")` / `document.addEventListener("touchstart")` listeners attached in:
+  - `MultiSelect` component (line 44 of `src/components/Primitive/MultiSelect/MultiSelect.tsx`)
+  - `Dropdown` component (lines 61-62 of `src/components/Primitive/Dropdown/Dropdown.tsx`)
+  
+  Each instance of these components adds listeners to document without deduplication.
+- Files: `src/components/Primitive/MultiSelect/MultiSelect.tsx`, `src/components/Primitive/Dropdown/Dropdown.tsx`
+- Cause: Both components independently implement click-outside-to-close pattern, resulting in multiple listeners for same event on document.
+- Improvement path: Extract click-outside detection into shared hook (`useClickOutside`) to prevent listener duplication. Ensure single listener per dropdown instance.
+
+**Mobile Navbar Resize Listener Every Render:**
+- Problem: `MobileNavbar` component creates resize listener in useEffect (`src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx`, lines 24-35) but doesn't include `isOpen` in dependency array.
+- Files: `src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx`
+- Cause: Missing dependency makes listener stale. New listeners are added on every state change without proper cleanup.
+- Improvement path: Add `isOpen` to dependency array, or consider moving outside logic to separate hook. Add AbortController for more granular listener cleanup.
+
+## Fragile Areas
+
+**Form Error Handling Ambiguity:**
+- Problem: `SignUpForm` component (`src/components/Composite/SignUpForm/SignUpForm.tsx`) has asymmetric error handling. Catches 409 conflicts with specific toast message, but all other errors (400, 500, network errors) show generic "An error occurred" message.
+- Files: `src/components/Composite/SignUpForm/SignUpForm.tsx`, `src/app/api/sign-up/route.ts`
+- Why fragile: API route throws unhandled errors (line 22: `throw err`). If Payload validation returns unexpected error format, the 409 detection logic (lines 16-18 of route.ts) will fail silently, and user sees generic error with no useful information.
+- Safe modification: Add proper error logging on backend. Define explicit error response shapes. Test with unexpected validation error formats. Add client-side logging for debugging.
+- Test coverage: No tests for error paths in SignUpForm.
+
+**Type Safety Gap in TeamPageClient:**
+- Problem: `TeamPageClient` component (`src/app/(frontend)/team/_components/TeamPageClient.tsx`) uses type coercion without validation in `toTeam` function (lines 82-87):
+  ```typescript
+  const toTeam = (str: string): ExecutiveTeam => {
+    if (Object.values(ExecutiveTeam).includes(str as ExecutiveTeam)) {
+      return str as ExecutiveTeam
+    }
+    throw new Error(`Invalid team: ${str}`)
+  }
+  ```
+- Files: `src/app/(frontend)/team/_components/TeamPageClient.tsx`
+- Why fragile: If `execsInTeam` filters return data with unexpected team values, or if database data is corrupted, runtime error thrown. No client-side error boundary to catch this.
+- Safe modification: Add error boundary around component. Return null team value instead of throwing. Add data validation at fetch time. Log invalid teams for monitoring.
+- Test coverage: No tests for invalid team data handling.
+
+**Missing Error Boundaries:**
+- Problem: No `error.tsx` files found in route directories. Server components can throw unhandled errors with no fallback UI.
+- Files: `src/app/(frontend)/`, `src/app/api/`
+- Cause: Error boundaries not implemented for frontend routes or API error handling.
+- Impact: Any unhandled error in server component causes blank page. API errors return raw error responses instead of standardized format.
+- Safe modification: Add `error.tsx` to all route segments. Wrap API responses in try-catch with standardized error format.
+
+**Member Schema Validation Type Mismatch:**
+- Problem: `Member` collection schema (`src/payload/collections/Member.ts`) defines `otherMajors` as `type: "text"` with `hasMany: true`, but form sends this as string array. Database validation relies on Payload's implicit type coercion.
+- Files: `src/payload/collections/Member.ts`, `src/types/schemas/member.ts`
+- Cause: Type definition should be explicit in Payload schema. Currently relies on Payload CMS internals to handle array serialization.
+- Impact: If Payload version changes or validation logic updates, array handling may break.
+- Safe modification: Verify Payload handles `text` type with `hasMany: true` correctly. Add explicit serialization tests. Consider using Payload's `array` type instead if available.
+
+**Hardcoded Gender and Study Year Options:**
+- Problem: Form options are hardcoded in two places:
+  - `SignUpForm.tsx` (lines 129, 163-168)
+  - `Member.ts` schema (lines 98-119)
+  
+  Options must be kept in sync manually.
+- Files: `src/components/Composite/SignUpForm/SignUpForm.tsx`, `src/payload/collections/Member.ts`
+- Impact: Adding new options requires changes in multiple files. Easier to miss one location and create data inconsistency.
+- Safe modification: Extract options to single source of truth enum/constant. Import in both schema and form.
+
+## Missing Critical Features
+
+**No Input Sanitization:**
+- Problem: Form inputs from `SignUpForm` sent directly to API without sanitization. Comment fields and text inputs like "heardAboutUs" accept any text.
+- Files: `src/app/api/sign-up/route.ts`
+- Impact: Risk of stored XSS if data is later displayed without escaping. No protection against spam/abuse.
+- Recommendation: Add input sanitization middleware or use schema validation with trimming/filtering (Zod `.trim()` methods). Consider rate limiting on sign-up endpoint.
+
+**No API Rate Limiting:**
+- Problem: `/api/sign-up` endpoint has no rate limiting or CAPTCHA protection.
+- Files: `src/app/api/sign-up/route.ts`
+- Impact: Endpoint vulnerable to spam attacks, bot registrations, brute force email enumeration (409 response reveals if email exists).
+- Recommendation: Implement rate limiting (IP-based, per-session). Add CAPTCHA (hCaptcha, reCAPTCHA) to form. Log suspicious activity.
+
+**No Data Export/Privacy Compliance:**
+- Problem: Member data is stored but no mechanism to export member data for GDPR compliance.
+- Files: `src/payload/collections/Member.ts`
+- Impact: If member requests their data, no automated way to provide it. Violates GDPR Article 15 (right to access).
+- Recommendation: Add endpoint to export member data in standard format (JSON/CSV). Implement data deletion mechanism.
+
+## Security Considerations
+
+**S3 Credentials in Memory:**
+- Risk: S3 credentials passed as plain objects in Payload S3 storage config (`src/payload.config.ts`, lines 60-67). Credentials visible in process memory and potentially in error logs.
+- Files: `src/payload.config.ts`
+- Current mitigation: Environment variables used (best practice for secret management).
+- Recommendations: 
+  - Use AWS IAM roles instead of access keys if running on AWS/compatible service.
+  - Ensure S3 bucket has appropriate ACLs and block public access.
+  - Rotate credentials regularly.
+  - Add bucket versioning to protect against accidental deletions.
+
+**Database URI in Env:**
+- Risk: MongoDB connection string in environment variable may contain password in plaintext.
+- Files: `src/payload.config.ts`
+- Current mitigation: Likely in `.env` (not committed to git).
+- Recommendations: Use connection string with IP whitelisting. Enable MongoDB authentication. Use IAM database authentication if provider supports.
+
+**NEXT_PUBLIC_URL Fallback to Localhost:**
+- Risk: In `src/app/(frontend)/layout.tsx` (line 42), `NEXT_PUBLIC_URL` falls back to `http://localhost:3000` if not set in production.
+- Files: `src/app/(frontend)/layout.tsx`
+- Impact: Open Graph metadata will use localhost URL in production if env not set, causing social media preview failures. Not a security risk but a deployment risk.
+- Recommendation: Make NEXT_PUBLIC_URL required for production builds. Fail fast if missing.
+
+**EventWishlist Field Name Case Mismatch:**
+- Risk: Form submits `eventWishlist` but Member schema defines it as `eventWishList` (capital L) on line 134.
+- Files: `src/components/Composite/SignUpForm/SignUpForm.tsx` (line 209), `src/payload/collections/Member.ts` (line 134)
+- Impact: Form field will not match schema field. Data may be stored under wrong key or validation may fail silently.
+- Recommendation: Standardize naming convention (camelCase vs other). Add schema validation tests to catch mismatches.
+
+## Test Coverage Gaps
+
+**No Unit Tests:**
+- What's not tested: No test files found in `src/` directory despite test infrastructure in place (Vitest, Storybook, Playwright).
+- Files: All source files lack corresponding `.test.ts` or `.spec.ts` files
+- Risk: Cannot confidently refactor or optimize code. Breaking changes not caught before deployment.
+- Priority: High
+
+**API Routes Not Tested:**
+- What's not tested: `/api/sign-up` error cases (malformed input, database errors, 409 conflicts)
+- Files: `src/app/api/sign-up/route.ts`
+- Risk: Error handling paths never executed in testing. Unknown if error responses format correctly.
+- Priority: High
+
+**Form Component Not Tested:**
+- What's not tested: SignUpForm validation, error messages, async submission, loading state
+- Files: `src/components/Composite/SignUpForm/SignUpForm.tsx`
+- Risk: Form regressions released to production. UX bugs in form flow.
+- Priority: High
+
+**Click-Outside Behavior Not Tested:**
+- What's not tested: Dropdown/MultiSelect click-outside detection, keyboard interactions
+- Files: `src/components/Primitive/Dropdown/Dropdown.tsx`, `src/components/Primitive/MultiSelect/MultiSelect.tsx`
+- Risk: UI becomes unresponsive or stuck open in production without detection.
+- Priority: Medium
+
+## Scaling Limits
+
+**Payload Types File Growth:**
+- Current capacity: 1002 lines for generated types
+- Limit: As schema grows (more collections, fields), generated file will grow. May impact build times and IDE responsiveness.
+- Scaling path: Monitor file size. Consider breaking into separate type modules per collection if > 2000 lines.
+
+**Database Query Optimization Unknown:**
+- Current: No database query optimization visible (no indexes, aggregation pipelines, or query analysis).
+- Limit: As member table grows (100s of thousands of records), filters on form data may slow down without proper indexing.
+- Scaling path: Add database indexes on frequently queried fields (`email` is already unique). Profile queries with production data load.
+
+---
+
+*Concerns audit: 2026-04-02*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,214 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-04-02
+
+## Naming Patterns
+
+**Files:**
+- PascalCase for component files: `BorderButton.tsx`, `Input.tsx`, `SignUpForm.tsx`
+- camelCase for utility/helper files: `utils.ts`, `helpers.ts`, `payload.ts`, `constants.ts`, `routes.ts`
+- `.stories.tsx` suffix for Storybook files: `BorderButton.stories.tsx`, `Input.stories.tsx`
+- `.mock.ts` suffix for mock data files: `Executive.mock.ts`, `Sponsor.mock.ts`
+
+**Functions:**
+- camelCase for all function and variable names: `getSocialLinks()`, `cn()`, `createMemberSchema`
+- Async functions named with action verbs: `getSocialLinks()`, `findGlobal()`, `create()`
+- Event handlers prefixed with `on`: `onSubmit()`, `onChange()`
+
+**Variables:**
+- camelCase for all variables and constants: `isCompsciStudent`, `resolvedReels`, `mockExecutive`
+- UPPERCASE for enum values: `SponsorTier.DIAMOND`, `ExecutiveLevel.PRESIDENT`
+- Const assertions for read-only arrays: `SPONSOR_TIER_ORDER`, `EXECUTIVE_LEVEL_ORDER`
+
+**Types:**
+- PascalCase for interfaces and types: `BorderButtonProps`, `InputProps`, `Value`, `Executive`
+- Suffix with `Props` for component prop interfaces: `BorderButtonProps`, `InputProps`
+- Discriminated unions used for variants: `BorderButtonVariantProps`
+
+**Enums:**
+- PascalCase for enum names: `SponsorTier`, `ExecutiveTeam`, `ExecutiveLevel`, `ValueColour`
+- UPPERCASE for enum variants: `DIAMOND`, `GOLD`, `SILVER`
+
+## Code Style
+
+**Formatting:**
+- Tool: Biome 2.4.6
+- Indentation: 2 spaces
+- Line ending: LF
+- Line width: 100 characters
+- Semicolons: asNeeded (no semicolons required)
+
+**Linting:**
+- Tool: Biome (enabled for JavaScript and React)
+- JSX quote style: double quotes
+- Trailing commas: all (in multiline constructs)
+- Arrow parentheses: always (even for single params)
+
+**Key Rules:**
+- `noUnusedVariables`: error - all variables must be used
+- `noUnusedImports`: error - all imports must be used
+- `noExplicitAny`: warn - avoid any types
+- `noParameterAssign`: error - don't reassign function parameters
+- `useAsConstAssertion`: error - use `as const` for literal types
+- `useDefaultParameterLast`: error - default params must come after required params
+- `useSelfClosingElements`: error - self-close empty JSX elements
+- `useSingleVarDeclarator`: error - one variable declaration per line
+- `useConsistentCurlyBraces`: error - require consistent braces in control flow
+
+## Import Organization
+
+**Order:**
+1. External libraries (React, Next.js, third-party packages)
+2. Relative imports from other parts of the codebase
+3. Type imports marked with `type` keyword
+
+**Pattern:**
+```typescript
+import { cn } from "@/lib/utils"
+import type { BorderButtonVariantProps } from "./variants"
+import { borderButtonVariants } from "./variants"
+```
+
+**Path Aliases:**
+- `@/*` → `./src/*` - Primary alias for all internal modules
+- `@payload-config` → `./src/payload.config.ts` - Special alias for Payload config
+
+**Re-exports:**
+- Barrel files (`index.ts`) used to export all components from a directory
+- Example: `src/components/Primitive/index.ts` exports all primitive components
+
+## Error Handling
+
+**Patterns:**
+- Try-catch blocks for async operations in route handlers and client-side functions
+- Specific error type checks: `if (err instanceof ValidationError)`
+- Payload ValidationError used for database/validation errors
+- Generic error messages returned to client to prevent information leakage
+
+Example from `src/app/api/sign-up/route.ts`:
+```typescript
+try {
+  const createdMember = await payload.create({
+    collection: "member",
+    data: member,
+  })
+  return new Response(JSON.stringify(createdMember), { status: 201 })
+} catch (err) {
+  if (err instanceof ValidationError && err.data?.errors?.some(...)) {
+    return new Response(JSON.stringify({ error: "Value already in use" }), { status: 409 })
+  }
+  throw err
+}
+```
+
+## Logging
+
+**Framework:** console (no dedicated logging library)
+
+**Patterns:**
+- No explicit logging patterns in codebase - developers use console methods as needed
+- Error logging handled through exception throwing in API routes
+
+## Comments
+
+**When to Comment:**
+- JSDoc comments used for public exports and function parameters
+- Inline comments rare - code is self-documenting through clear naming
+- File-level documentation in interfaces and component exports
+
+**JSDoc/TSDoc:**
+- Used extensively on component props and public functions
+- Format: `/** ... */` with description lines starting with `*`
+- Parameter documentation using `@param` tags
+- Return documentation rarely used (types are self-documenting)
+
+Example from `src/components/Primitive/BorderButton/BorderButton.tsx`:
+```typescript
+/**
+ * Props for the {@link BorderButton} component.
+ */
+export interface BorderButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * The content of the button to live in the middle of the button.
+   */
+  children: React.ReactNode
+  /**
+   * Variant configuration for the button.
+   */
+  variant?: BorderButtonVariantProps
+}
+
+/**
+ * A primitive Button component that supports various themes, sizes, and border options.
+ *
+ * @param props {@link BorderButtonProps} for the Button component.
+ * @returns A styled button element.
+ */
+export const BorderButton = ({ ... }: BorderButtonProps) => { ... }
+```
+
+## Function Design
+
+**Size:** Functions are kept small and focused, typically under 50 lines
+
+**Parameters:**
+- Destructured from props objects in React components
+- Typed using interfaces extending component base types
+- Rest parameters (`...props`) used to pass through HTML attributes
+
+**Return Values:**
+- React components return JSX elements
+- Async functions return Promises
+- Utility functions return simple values or objects
+
+Example pattern from `src/components/Primitive/Input/Input.tsx`:
+```typescript
+export const Input = ({
+  label,
+  error,
+  containerClassName,
+  className,
+  required,
+  ref,
+  ...props
+}: InputProps) => { ... }
+```
+
+## Module Design
+
+**Exports:**
+- Named exports used for all components and utilities
+- Default exports used only in Storybook stories (`export default meta`)
+- Types exported with `export type` or `export interface`
+
+**Structure:**
+- Components grouped by type: `Primitive/`, `Composite/`, `Generic/`
+- Each component typically in its own directory with accompanying files
+- Styles co-located or defined via Tailwind utilities
+
+**Barrel Files:**
+- Used to simplify imports: `export * from "./Component"`
+- Example: `src/components/Primitive/index.ts` exports all primitives
+- Reduces import depth when consuming multiple components
+
+## Special Patterns
+
+**React Hook Form Integration:**
+- `useForm` with Zod schema validation via `zodResolver`
+- `Controller` wrapper for custom components
+- Form state destructured: `control`, `register`, `handleSubmit`, `watch`, `formState`
+
+**Type Safety:**
+- Zod schemas used for runtime validation and type inference
+- `z.input<T>` and `z.output<T>` used for form input/output types
+- `satisfies` keyword used to ensure types match: `memberSchema satisfies z.ZodType<Member>`
+
+**Next.js Patterns:**
+- Server Components (default) for data fetching and layout
+- `"use client"` directive for interactive components
+- Dynamic metadata via `export const metadata: Metadata = { ... }`
+- Promise.all for concurrent async operations
+
+---
+
+*Convention analysis: 2026-04-02*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,159 @@
+# External Integrations
+
+**Analysis Date:** 2026-04-02
+
+## APIs & External Services
+
+**None detected** - The application does not consume external REST/GraphQL APIs beyond Payload CMS internal APIs.
+
+## Data Storage
+
+**Databases:**
+- MongoDB
+  - Connection: `DATABASE_URI` env var (required)
+  - Client/Adapter: @payloadcms/db-mongodb 3.80.0
+  - Configuration: `src/payload.config.ts` lines 46-48
+  - Collections managed: User, Media, Member, Executive, Sponsor, Reel, Polaroid
+  - Payload generates types to: `src/payload/payload-types.ts`
+
+**File Storage:**
+- AWS S3 (primary storage)
+  - SDK/Plugin: @payloadcms/storage-s3 3.80.0
+  - Configuration: `src/payload.config.ts` lines 56-68
+  - Bucket: `S3_BUCKET` env var (required)
+  - Prefix: "media" for media collection files
+  - Credentials: `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` env vars
+  - Region: `S3_REGION` env var
+  - File size limit: 32MB (33_554_432 bytes)
+
+**Image Processing:**
+- Sharp 0.34.4
+  - Used for image optimization during upload
+  - Integrated in Payload config (`src/payload.config.ts` line 49)
+  - Handles image processing for media collection
+
+**Caching:**
+- None detected - No explicit caching layer (Redis, Memcached, etc.)
+- Next.js built-in caching via revalidatePath hooks
+
+## Authentication & Identity
+
+**Auth Provider:**
+- Payload CMS Custom - Built-in authentication
+  - Admin user collection: `User` (slug defined in payload.config.ts)
+  - Authentication via Payload admin interface
+  - No external OAuth/OIDC detected
+
+**Protected Routes:**
+- Payload admin: `/payload/admin` (access controlled by User collection)
+- API endpoints: Public by default, gated via Payload's access control
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None detected - No Sentry, Rollbar, DataDog, etc.
+
+**Logs:**
+- Console logging - Via Payload logger (payload.logger.info)
+- Example: Revalidation logs in `src/payload/hooks/revalidate.ts` lines 14
+- Deployment logs: Via Fly.io dashboard
+
+**Health Checks:**
+- Endpoint: `/api/health` (GET)
+- Purpose: Fly.io health check (configured in fly.toml)
+- Interval: 15 seconds
+- Grace period: 30 seconds
+- Timeout: 10 seconds
+- Returns: HTTP 200 from `src/app/api/health/route.ts`
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Fly.io (primary)
+  - App name: `uoacs-website`
+  - Primary region: Sydney (syd)
+  - Concurrency: 20 soft limit, 25 hard limit
+  - Min machines: 1 always running
+  - Swap: 256MB
+
+**Staging:**
+- Configured: `fly.staging.toml`
+- Deployment environment: Separate Fly app
+
+**CI Pipeline:**
+- None detected in codebase
+- No GitHub Actions, GitLab CI, etc. configured
+
+**Build Process:**
+- Docker multi-stage build (Dockerfile)
+- Stage 1: deps - Install dependencies
+- Stage 2: builder - Build Next.js app
+- Uses pnpm with frozen lockfile
+- Secrets: DATABASE_URI, PAYLOAD_SECRET, NEXT_PUBLIC_URL, S3_*
+
+## Environment Configuration
+
+**Required env vars:**
+- `DATABASE_URI` - MongoDB connection string
+- `PAYLOAD_SECRET` - Secret for Payload CMS
+- `NEXT_PUBLIC_URL` - Public app URL (visible in browser)
+  - Used for: OG tags, sitemap, metadata base URL
+  - Default fallback: `http://localhost:3000`
+- `S3_BUCKET` - AWS S3 bucket name
+- `S3_ACCESS_KEY_ID` - AWS S3 access key
+- `S3_SECRET_ACCESS_KEY` - AWS S3 secret key
+- `S3_REGION` - AWS region for S3
+
+**Optional env vars:**
+- `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` - Default to empty strings if not set (lines 60, 63-64 in payload.config.ts)
+
+**Secrets location:**
+- `.env` file (local development, not committed)
+- Docker secrets: Referenced in Dockerfile via `--mount=type=secret`
+- Fly.io secrets: Managed via Fly dashboard (not in codebase)
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None detected
+
+**Outgoing:**
+- ISR/Revalidation: Next.js revalidatePath() hooks
+  - Triggered by: Payload collection changes and deletes
+  - Implementation: `src/payload/hooks/revalidate.ts`
+  - Used for: Cache invalidation of static pages
+  - Collections: Member, Executive, Sponsor, Reel, Polaroid, Media, and globals (HomePage, PrivacyPolicy, SocialLinks)
+
+## Data Models
+
+**Payload Collections:**
+- `user` - Admin users (`src/payload/collections/User.ts`)
+- `media` - Files with S3 storage (`src/payload/collections/Media.ts`)
+- `member` - Community members with email uniqueness constraint
+- `executive` - Leadership team data (`src/payload/collections/Executive.ts`)
+- `sponsor` - Sponsors with links (`src/payload/collections/Sponsor.ts`)
+- `reel` - Video/media content (`src/payload/collections/Reel.ts`)
+- `polaroid` - Photo gallery items (`src/payload/collections/Polaroid.ts`)
+
+**Payload Globals:**
+- `home-page` - Homepage content (`src/payload/globals/HomePage.ts`)
+- `privacy-policy` - Privacy policy content (`src/payload/globals/PrivacyPolicy.ts`)
+- `social-links` - Social media links (`src/payload/globals/SocialLinks.ts`)
+
+## API Endpoints
+
+**Public:**
+- `GET /api/health` - Health check (src/app/api/health/route.ts)
+- `POST /api/sign-up` - Create new member (src/app/api/sign-up/route.ts)
+- `GET /api/og` - OG image generation (src/app/og/route.tsx)
+
+**Payload Admin API:**
+- `GET/POST /payload/api/*` - Authenticated CMS API
+- Type definitions auto-generated to `src/payload/payload-types.ts`
+
+**Payload Admin UI:**
+- `GET /payload/admin` - Admin dashboard (requires User authentication)
+
+---
+
+*Integration audit: 2026-04-02*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,142 @@
+# Technology Stack
+
+**Analysis Date:** 2026-04-02
+
+## Languages
+
+**Primary:**
+- TypeScript 5.x - All source code (.ts, .tsx files)
+- JavaScript - Configuration files and build scripts
+
+**Secondary:**
+- JSX/TSX - React component syntax
+- CSS - Global and component styles (via Tailwind)
+
+## Runtime
+
+**Environment:**
+- Node.js 24.14.0 - Specified in `.nvmrc`
+- Docker support: Alpine Linux base (Node 24.12.0)
+
+**Package Manager:**
+- pnpm 10.27.0 - Lockfile: `pnpm-lock.yaml` (present)
+- Built dependencies: @tailwindcss/oxide, core-js-pure, esbuild, lefthook, sharp
+
+## Frameworks
+
+**Core:**
+- Next.js 16.2.1 - Full-stack React framework
+  - Features: App Router (Next/13+), Server Components, API Routes
+  - React Compiler enabled (`reactCompiler: true` in next.config.ts)
+  - Standalone output format for Docker
+
+**Backend/CMS:**
+- Payload CMS 3.80.0 - Headless CMS and admin panel
+  - Admin route: `/payload/admin`
+  - API route: `/payload/api`
+  - Configuration: `src/payload.config.ts`
+
+**UI & Styling:**
+- React 19.2.4 - UI library
+- Tailwind CSS 4.1.18 - Utility-first CSS framework
+- Tailwind Variants 3.1.1 - Component variant system
+- Tailwind Merge 3.3.1 - Merge utility class names
+
+**Testing:**
+- Vitest 4.0.18 - Unit/integration test runner
+- Playwright 1.58.1 - Browser testing via @vitest/browser-playwright
+- Storybook 10.2.7 - Component development and visual testing
+
+**Build/Dev:**
+- Turbopack - Next.js bundler (via Turbo)
+- PostCSS 4.x (via @tailwindcss/postcss)
+- Biome 2.4.6 - Linter and formatter
+
+## Key Dependencies
+
+**Critical:**
+- Payload CMS 3.80.0 - Headless content management system
+  - @payloadcms/next 3.80.0 - Next.js integration
+  - @payloadcms/richtext-lexical 3.80.0 - Rich text editor
+  - @payloadcms/db-mongodb 3.80.0 - MongoDB database adapter
+  - @payloadcms/storage-s3 3.80.0 - AWS S3 file storage
+  - @payloadcms/plugin-import-export 3.80.0 - Data import/export utilities
+  - @payloadcms/payload-cloud 3.80.0 - Payload Cloud integration
+  - payload 3.80.0 - Core CMS engine
+
+**Data & Validation:**
+- Zod 4.3.6 - TypeScript-first schema validation
+- react-hook-form 7.71.2 - Form state management
+- @hookform/resolvers 5.2.2 - Integration with validation schemas
+
+**Media & Image Processing:**
+- Sharp 0.34.4 - Image processing (critical for onlyBuiltDependencies)
+- GraphQL 16.11.0 - Graph query language (disabled in config but installed)
+
+**UI Components & Effects:**
+- @heroicons/react 2.2.0 - Icon library
+- Motion 12.23.24 - Animation library
+- react-smart-ticker 1.6.7 - Ticker/scrolling text component
+- Sonner 2.0.7 - Toast notifications
+
+**Utilities:**
+- clsx 2.1.1 - Class name concatenation
+- Babel React Compiler Plugin 1.0.0 - React performance optimization
+
+**Development Tools:**
+- TypeScript 5.x - Type checking (`pnpm types:check` for full check)
+- @types/* packages - Type definitions for Node, React
+
+## Configuration
+
+**Environment:**
+- `.env` file present - Contains environment configuration
+- `.env.example` - Template for required env vars
+- Key variables: `DATABASE_URI`, `PAYLOAD_SECRET`, `S3_*`, `NEXT_PUBLIC_URL`
+
+**Build:**
+- `next.config.ts` - Next.js configuration with Payload integration
+- `tsconfig.json` - TypeScript compiler options
+  - Path aliases: `@/*` → `./src/*`, `@payload-config` → `./src/payload.config.ts`
+  - Target: ES2017, Module: esnext
+- `postcss.config.mjs` - PostCSS configuration with Tailwind
+- `biome.json` - Linting and formatting rules (100 character line width)
+- `.nvmrc` - Node version specification
+
+**Container:**
+- `Dockerfile` - Multi-stage Docker build (Node Alpine)
+- `docker-compose` - Not detected
+- `fly.toml` - Fly.io deployment configuration (primary)
+- `fly.staging.toml` - Staging environment configuration
+
+## Platform Requirements
+
+**Development:**
+- Node.js 24.14.0
+- pnpm 10.27.0
+- Git hooks via lefthook 1.x
+
+**Production:**
+- Fly.io hosting (configured in fly.toml)
+- MongoDB instance (via DATABASE_URI)
+- AWS S3 bucket (via S3_* env vars)
+- 512MB memory, 1 shared CPU on Fly.io
+- HTTPS enforcement, health checks every 15s
+
+**Scripts:**
+```bash
+pnpm dev                  # Start development server
+pnpm build                # Build for production
+pnpm start                # Start production server
+pnpm types:check          # Type checking with tsc
+pnpm types:generate       # Generate Payload types
+pnpm lint:check           # Lint with Biome
+pnpm lint:fix             # Auto-fix linting issues
+pnpm lint:fix:unsafe      # Auto-fix with unsafe transformations
+pnpm storybook            # Start Storybook dev server
+pnpm storybook:build      # Build Storybook
+```
+
+---
+
+*Stack analysis: 2026-04-02*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,300 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-04-02
+
+## Directory Layout
+
+```
+/Users/mikaisomerville/localdocs/UOACS-Website/
+├── src/                            # Main source code
+│   ├── app/                        # Next.js app directory (routes & pages)
+│   │   ├── (frontend)/             # Public website pages (route group)
+│   │   ├── api/                    # REST API routes
+│   │   ├── payload/                # Payload CMS routes (admin & API proxy)
+│   │   └── og/                     # OpenGraph image generation
+│   ├── components/                 # React components (3-tier hierarchy)
+│   │   ├── Primitive/              # Base UI elements
+│   │   ├── Generic/                # Reusable UI patterns
+│   │   └── Composite/              # Full sections & forms
+│   ├── lib/                        # Utility functions & constants
+│   ├── payload/                    # Payload CMS configuration
+│   │   ├── collections/            # Data models (Member, Executive, etc.)
+│   │   ├── globals/                # Global settings (HomePage, SocialLinks, etc.)
+│   │   └── hooks/                  # Payload hooks (revalidation, etc.)
+│   ├── types/                      # TypeScript type definitions
+│   │   └── schemas/                # Zod validation schemas
+│   ├── mocks/                      # Mock data for testing/development
+│   ├── payload.config.ts           # Payload CMS root config
+│   └── app/(frontend)/globals.css  # Global styles
+├── public/                         # Static assets
+│   └── fonts/                      # Web fonts
+├── .storybook/                     # Storybook config
+├── .planning/                      # GSD planning documents
+│   └── codebase/                   # Architecture & analysis docs
+├── node_modules/                   # Dependencies
+├── package.json                    # Project metadata & scripts
+├── tsconfig.json                   # TypeScript configuration
+├── next.config.ts                  # Next.js configuration
+├── vitest.config.ts                # Vitest configuration
+├── postcss.config.mjs              # PostCSS configuration
+└── .env                            # Environment variables (secrets)
+```
+
+## Directory Purposes
+
+**`src/app/`** — Next.js App Router with route groups and API handlers
+- Contains page components (async Server Components)
+- API route handlers for REST endpoints
+- Payload CMS integration routes
+
+**`src/app/(frontend)/`** — Public website pages
+- Route group providing shared layout and structure
+- Contains pages: home, team, sponsors, sign-up, privacy
+- _components subdirectories for page-specific client components
+
+**`src/app/api/`** — Backend REST endpoints
+- `sign-up/route.ts` — POST endpoint for member registration
+- `health/route.ts` — Health check endpoint
+
+**`src/app/payload/`** — Payload CMS integration
+- `admin/[[...segments]]/page.tsx` — Admin UI entry point
+- `api/[...slug]/route.ts` — API proxy to Payload endpoints
+- `layout.tsx` — Layout for Payload routes
+
+**`src/components/`** — Reusable React components in 3 layers
+
+**`src/components/Primitive/`** — Basic unstyled/lightly styled elements
+- `Button/` — Clickable button with variants (dark/light)
+- `Input/` — Text input with validation error display
+- `Radio/` — Radio button group
+- `Select/` — Dropdown select
+- `MultiSelect/` — Multi-select dropdown
+- `Heading/` — Heading component with responsive sizing
+- `Container/` — Layout container
+- `Icons/` — Icon components
+- `LazyImage/` — Image with lazy loading
+- `BorderButton/` — Button with border styling
+- `Toast/` — Toast notification display
+- `Dropdown/` — Dropdown menu
+
+**`src/components/Generic/`** — Reusable composite patterns
+- `ExecCard/` — Executive team member card
+- `Section/` — Page section wrapper
+- `SocialLinks/` — Social media link list
+- `SponsorBadge/` — Sponsor logo badge
+- `SponsorTicker/` — Animated sponsor ticker
+- `Polaroid/` — Polaroid-style image card
+- `ValueCard/` — Value proposition card
+- `ValuesAccordion/` — Expandable values list
+- `ValuesFingerprint/` — Visual values representation
+
+**`src/components/Composite/`** — Full page sections & forms
+- `HeroSection/` — Hero banner section
+- `AboutUsSection/` — About Us with reels
+- `WhoWeAreSection/` — Team/culture section with polaroids
+- `ValuesSection/` — Values carousel section
+- `ValuesCarousel/` — Carousel of values
+- `SponsorsSection/` — Sponsors grid
+- `SignUpForm/` — Member registration form
+- `Navbar/` — Navigation bar with links & social
+- `Footer/` — Footer with navigation
+- `Reel/` — Instagram reel embed
+
+**`src/lib/`** — Utility functions and constants
+- `helpers.ts` — `getSocialLinks()` - fetches social links from Payload
+- `payload.ts` — Payload SDK initialization
+- `routes.ts` — Route constants (Routes.HOME, ApiRoutes.SIGN_UP)
+- `slugs.ts` — Collection/global slug definitions
+- `toast.tsx` — Toast notification helpers (success, error, warning)
+- `utils.ts` — General utilities (cn for className merging)
+- `constants.ts` — Application constants
+- `enums.ts` — Enum types (ExecutiveTeam, ExecutiveLevel, SponsorTier, ValueColour)
+
+**`src/payload/`** — Payload CMS configuration and definitions
+
+**`src/payload/collections/`** — Data model definitions
+- `User.ts` — Admin user account
+- `Member.ts` — Sign-up member (firstName, lastName, email, UPI, year, etc.)
+- `Executive.ts` — Executive team member (name, role, photo, level)
+- `Sponsor.ts` — Sponsor (name, logo, link, tier)
+- `Reel.ts` — Instagram reel link
+- `Polaroid.ts` — Polaroid image with caption
+- `Media.ts` — File upload collection (alt text required)
+
+**`src/payload/globals/`** — Global settings
+- `HomePage.ts` — Homepage content (reels, polaroids relationships)
+- `PrivacyPolicy.ts` — Privacy policy text
+- `SocialLinks.ts` — Social media links (Discord, Instagram, TikTok, LinkedIn)
+
+**`src/payload/hooks/`** — Payload lifecycle hooks
+- `revalidate.ts` — `makeRevalidateHooks()` factory that triggers Next.js ISR invalidation
+
+**`src/types/`** — TypeScript definitions
+- `common.ts` — Shared interfaces (Value type)
+- `enums.ts` — Enum definitions (ExecutiveTeam, ExecutiveLevel, SponsorTier, ValueColour)
+- `schemas/` — Zod validation schemas
+
+**`src/types/schemas/`** — Zod validation
+- `member.ts` — `createMemberSchema` validates form input against Member collection
+
+**`src/mocks/`** — Mock data for testing
+
+**`src/payload/payload-types.ts`** — Auto-generated types (do not edit)
+- Generated by: `payload generate:types`
+- Contains: All TypeScript types from Payload schema (Executive, Member, Sponsor, etc.)
+
+**`public/`** — Static assets served directly
+- `fonts/` — Web fonts (Inter Tight, Switzer, IBM Plex Mono)
+
+**`.storybook/`** — Storybook component library config
+- Component documentation and visual testing
+
+## Key File Locations
+
+**Entry Points:**
+
+- `src/app/(frontend)/layout.tsx` — Root frontend layout (fonts, metadata, navbar/footer)
+- `src/app/payload/layout.tsx` — Payload admin layout
+- `src/app/(frontend)/page.tsx` — Homepage (fetches HomePage global + reels/polaroids)
+- `src/app/(frontend)/sign-up/page.tsx` — Sign-up page (renders SignUpForm component)
+
+**Configuration:**
+
+- `src/payload.config.ts` — Payload CMS main config (collections, globals, database, storage)
+- `tsconfig.json` — TypeScript config with `@/*` alias for `src/*` and `@payload-config`
+- `next.config.ts` — Next.js app config
+- `vitest.config.ts` — Test runner config
+- `postcss.config.mjs` — CSS post-processing config
+
+**Core Logic:**
+
+- `src/lib/payload.ts` — Payload SDK initialization (exported const `payload`)
+- `src/lib/helpers.ts` — `getSocialLinks()` helper for fetching global data
+- `src/lib/routes.ts` — Route and API endpoint string constants
+- `src/lib/slugs.ts` — Collection/global slug constants
+- `src/app/api/sign-up/route.ts` — Member registration endpoint
+
+**Testing:**
+
+- Component `.stories.tsx` files — Storybook stories (located alongside components)
+- No dedicated test files currently (components can have .test.tsx alongside)
+
+## Naming Conventions
+
+**Files:**
+
+- Components: PascalCase (e.g., `Button.tsx`, `HeroSection.tsx`)
+- Utilities/helpers: camelCase (e.g., `helpers.ts`, `utils.ts`)
+- Collections: PascalCase matching the model (e.g., `Executive.ts`, `Member.ts`)
+- Hooks: camelCase with `use` prefix for custom hooks (e.g., `useForm`)
+- Configs: camelCase (e.g., `payload.config.ts`)
+- Routes: lowercase with hyphens (e.g., `/sign-up`, `/team`)
+
+**Directories:**
+
+- Component directories: PascalCase (e.g., `src/components/Composite/HeroSection/`)
+- Feature directories: kebab-case or PascalCase based on function (e.g., `(frontend)`, `api`)
+- Config/infrastructure: lowercase (e.g., `src/payload/`, `src/lib/`)
+
+**Variables & Functions:**
+
+- Types/Interfaces: PascalCase (e.g., `AboutUsSectionProps`, `Value`)
+- Constants: UPPER_SNAKE_CASE for truly constant values (e.g., `START_YEAR`, `FILE_SIZE`)
+- Functions: camelCase (e.g., `getSocialLinks()`, `makeRevalidateHooks()`)
+- React Components: PascalCase (e.g., `HeroSection`, `Button`)
+- Enum values: PascalCase (e.g., `ExecutiveLevel.EXECUTIVE`)
+
+**Types/Interfaces:**
+
+- Collection types: Match collection slug (e.g., `Member`, `Executive`, `Sponsor`)
+- Props interfaces: ComponentName + `Props` suffix (e.g., `AboutUsSectionProps`)
+- Imported from `src/payload/payload-types.ts` for auto-generated types
+
+## Where to Add New Code
+
+**New Feature/Page:**
+
+1. Create page in `src/app/(frontend)/[feature-name]/page.tsx` (Server Component)
+2. Create page-specific layout/components in `src/app/(frontend)/[feature-name]/_components/`
+3. If components are shared across pages, extract to `src/components/Composite/`
+4. Create any new Payload collections/globals in `src/payload/collections/` or `src/payload/globals/`
+5. Add route constant to `src/lib/routes.ts`
+
+**New Reusable Component:**
+
+1. **If Primitive (basic element):** Create in `src/components/Primitive/ComponentName/`
+   - Add `ComponentName.tsx` with JSDoc comments
+   - Create `.stories.tsx` for Storybook docs
+   - Export from `src/components/Primitive/index.ts`
+
+2. **If Generic (reusable pattern):** Create in `src/components/Generic/ComponentName/`
+   - Likely combines multiple Primitives
+   - Include TypeScript interfaces for props
+   - Export from `src/components/Generic/index.ts`
+
+3. **If Composite (page section):** Create in `src/components/Composite/SectionName/`
+   - May fetch data, handle complex interactions
+   - Can use "use client" for interactivity
+   - Export from `src/components/Composite/index.ts`
+
+**New Data Collection:**
+
+1. Create collection config in `src/payload/collections/NewModel.ts` (e.g., `Event.ts`)
+2. Define fields with names matching database schema
+3. Add relationships to other collections using `relationTo`
+4. If content changes should trigger ISR, add hooks from `makeRevalidateHooks(routes)`
+5. Add slug constant to `src/lib/slugs.ts`
+6. Import and add to `collections` array in `src/payload.config.ts`
+7. Run `pnpm types:generate` to update `payload-types.ts`
+8. Create Zod schema in `src/types/schemas/` if used in forms
+
+**New API Route:**
+
+1. Create `src/app/api/[endpoint]/route.ts` (Next.js API route)
+2. Export `POST`, `GET`, etc. functions
+3. Use `payload.create()`, `payload.find()`, etc. for data access
+4. Validate input with Zod schema
+5. Return appropriate status codes (200, 201, 400, 409, 500)
+6. Add route constant to `src/lib/routes.ts` (ApiRoutes object)
+
+**New Type/Schema:**
+
+1. Create TypeScript interface/type in `src/types/common.ts` for shared types
+2. Create Zod schema in `src/types/schemas/[domain].ts` for form validation
+3. For Payload-generated types: run `pnpm types:generate` (auto-creates `src/payload/payload-types.ts`)
+
+**New Global/Constant:**
+
+- Routes: Add to `src/lib/routes.ts` (Routes or ApiRoutes object)
+- Slugs: Add to `src/lib/slugs.ts` (Slugs.Collections or Slugs.Globals)
+- Toast messages: Use `src/lib/toast.ts` helpers
+- Enums: Add to `src/types/enums.ts`
+
+## Special Directories
+
+**`.next/`** — Build output
+- Generated by: `pnpm build`
+- Contains: Compiled assets, static pages, etc.
+- Committed: No (add to .gitignore)
+
+**`node_modules/`** — Dependencies
+- Installed by: `pnpm install`
+- Committed: No (always in .gitignore)
+
+**`.storybook/`** — Component documentation
+- Used by: `pnpm storybook` for component library
+- Contains: Storybook config, decorators, preview settings
+
+**`public/`** — Static assets
+- Committed: Yes
+- Served at: `/` path (e.g., `/fonts/Inter.woff2`)
+- Contains: Fonts, logos, images
+
+**`src/payload/payload-types.ts`** — Auto-generated Payload types
+- Generated by: `pnpm types:generate`
+- Committed: Yes (source of truth for type definitions)
+- Do not edit manually — regenerate when schema changes
+
+---
+
+*Structure analysis: 2026-04-02*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,287 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-04-02
+
+## Test Framework
+
+**Runner:**
+- Vitest 4.0.18 - Primary test runner
+- Config: `vitest.config.ts`
+- Browser testing enabled via Playwright provider
+
+**Assertion Library:**
+- Built-in Vitest assertions
+
+**Test Browser Provider:**
+- Playwright with Chromium browser
+- Headless mode enabled
+- Single instance configuration
+
+**Run Commands:**
+```bash
+pnpm types:check              # Type check TypeScript
+pnpm test                     # Run tests (command not shown in package.json - uses default vitest)
+pnpm test:watch              # Watch mode (inferred from standard Vitest setup)
+pnpm test:coverage           # Coverage report (via @vitest/coverage-v8)
+```
+
+## Test File Organization
+
+**Location:**
+- No dedicated `.test.ts` or `.spec.ts` files found in repository
+- All testing currently done via Storybook component stories (`.stories.tsx` files)
+- Co-located with component files in same directory
+
+**Story Files Structure:**
+- 29 Storybook story files identified in `src/components/`
+- Pattern: One story file per component that needs documentation/testing
+- Located alongside component implementations
+
+**Directory Pattern:**
+```
+src/components/Primitive/[ComponentName]/
+├── [ComponentName].tsx          # Component implementation
+├── [ComponentName].stories.tsx  # Storybook stories (if UI needs testing/docs)
+└── variants.ts                  # Optional variant definitions
+```
+
+## Test Structure
+
+**Suite Organization:**
+```typescript
+// From src/components/Primitive/Input/Input.stories.tsx
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+import { Input } from "./Input"
+
+const meta: Meta<typeof Input> = {
+  title: "Primitive Components/Input",
+  component: Input,
+  args: { ... },
+  argTypes: { ... },
+}
+
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const Primary: Story = {}
+export const WithError: Story = { args: { ... } }
+export const Required: Story = { args: { ... } }
+```
+
+**Patterns:**
+- Storybook Meta object defines component title and default props
+- Story type aliases (`type Story = StoryObj<typeof Component>`) for cleaner exports
+- Named exports for each story variant
+- `argTypes` control configuration shows available props and controls
+
+**Setup:**
+- Vitest setup file: `.storybook/vitest.setup.ts`
+- Storybook Vitest plugin configured in `vitest.config.ts`
+- Accessibility (a11y) addon configured with "todo" level (violations shown but don't fail CI)
+
+Example from `.storybook/vitest.setup.ts`:
+```typescript
+import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview"
+import { setProjectAnnotations } from "@storybook/nextjs-vite"
+import * as projectAnnotations from "./preview"
+
+setProjectAnnotations([a11yAddonAnnotations, projectAnnotations])
+```
+
+## Mocking
+
+**Framework:** No explicit mocking framework configured
+
+**Patterns:**
+- Mock data files with `.mock.ts` suffix: `Executive.mock.ts`, `Sponsor.mock.ts`, `Reel.mock.ts`
+- Located in `src/mocks/` directory
+- Structured mock objects that extend real types for consistency
+
+Example from `src/mocks/Executive.mock.ts`:
+```typescript
+export const mockExecutive: Executive = {
+  id: "68e390f21023fb09c6a454da",
+  name: "Joshua Li",
+  isCurrent: true,
+  role: { ... },
+  updatedAt: "2025-05-01T12:00:00Z",
+  createdAt: "2024-05-01T12:00:00Z",
+}
+
+export const mockExecutiveWithPhoto: Executive = {
+  ...mockExecutive,
+  photo: { ... },
+}
+```
+
+**Mock Patterns:**
+- Spread operator used to build variations on base mock objects
+- Each mock is a named export for easy reuse
+- Types imported from actual Payload CMS types
+
+**What to Mock:**
+- External API responses and database entities
+- Media files and photo URLs
+- User data objects (executives, members, sponsors)
+
+**What NOT to Mock:**
+- React components (tested via Storybook instead)
+- Utility functions (assumed to work correctly)
+- Form validation logic (handled by Zod schemas)
+
+## Fixtures and Factories
+
+**Test Data:**
+- Mock data files serve as test fixtures
+- Each mock file contains multiple variations of the same entity
+- Objects built using spread operator for composition
+
+Example pattern from `src/mocks/Executive.mock.ts`:
+```typescript
+// Base mock
+export const mockExecutive: Executive = { ... }
+
+// Variations built from base
+export const mockExecutiveWithPhoto: Executive = {
+  ...mockExecutive,
+  photo: { ... },
+}
+
+export const mockExecutiveWithLinkedin: Executive = {
+  ...mockExecutiveWithPhoto,
+  linkedin: "https://www.linkedin.com/in/joshua-li",
+}
+
+export const mockExecutiveWithLinkedinFallback: Executive = {
+  ...mockExecutive,
+  linkedin: "https://www.linkedin.com/in/joshua-li",
+}
+```
+
+**Location:**
+- `src/mocks/` directory
+- Organized by entity type (Executive, Sponsor, Reel, etc.)
+- Imported directly in components or stories
+
+## Coverage
+
+**Requirements:** Not enforced (no coverage threshold configured)
+
+**View Coverage:**
+```bash
+pnpm test:coverage    # Generates coverage report via @vitest/coverage-v8
+```
+
+**Coverage Tool:**
+- `@vitest/coverage-v8` installed but coverage collection not actively enforced
+- Can be run manually to check coverage metrics
+
+## Test Types
+
+**Unit Tests:**
+- Scope: Individual component functionality
+- Approach: Storybook stories serve as visual unit tests
+- No unit test files (`.test.ts`/`.spec.ts`) present - relying on Storybook
+
+**Integration Tests:**
+- Scope: Form submission, API integration, data flow
+- Approach: Form testing via component stories with controlled inputs
+- Example: `SignUpForm.tsx` form validation tested through form story variations
+
+**E2E Tests:**
+- Framework: Vitest Browser with Playwright
+- Provider: Playwright + Chromium
+- Scope: Full application workflows
+- Not currently implemented (configuration present but no E2E test files)
+
+## Browser Testing
+
+**Configuration:**
+- Vitest browser plugin enabled in `vitest.config.ts`
+- Provider: Playwright
+- Browser: Chromium
+- Mode: Headless
+
+From `vitest.config.ts`:
+```typescript
+test: {
+  browser: {
+    enabled: true,
+    headless: true,
+    provider: playwright(),
+    instances: [{ browser: "chromium" }],
+  },
+}
+```
+
+## Storybook Integration
+
+**Setup:**
+- Storybook 10.2.7 with Next.js Vite integration
+- Addons configured:
+  - `@chromatic-com/storybook` - Visual regression testing
+  - `@storybook/addon-docs` - Documentation generation
+  - `@storybook/addon-onboarding` - Setup wizard
+  - `@storybook/addon-a11y` - Accessibility testing
+  - `@storybook/addon-vitest` - Vitest integration
+
+**Run Commands:**
+```bash
+pnpm storybook              # Start Storybook dev server on port 6006
+pnpm storybook:build        # Build static Storybook
+```
+
+## Testing Best Practices
+
+**Component Stories:**
+- Each story represents a distinct state or variant
+- Named exports: `Primary`, `WithError`, `Required`, `Email`, etc.
+- Args define default props for the story
+- ArgTypes define prop controls shown in Storybook UI
+
+**Form Testing Pattern:**
+- Create story variants for different form states
+- Test error states with error messages
+- Test required vs optional fields
+- Test different input types and options
+
+Example from input testing:
+```typescript
+export const Primary: Story = {}
+export const WithError: Story = {
+  args: { error: "This field is required" }
+}
+export const Required: Story = {
+  args: { required: true }
+}
+export const Email: Story = {
+  args: { label: "Email", type: "email" }
+}
+```
+
+**Accessibility Testing:**
+- Storybook a11y addon configured with "todo" level
+- Violations shown in test UI but don't fail CI
+- Can be upgraded to "error" level to enforce strict a11y compliance
+
+## Configuration Files
+
+**Vitest Config:**
+- Location: `vitest.config.ts`
+- Storybook plugin integration via `@storybook/addon-vitest/vitest-plugin`
+- Setup file: `.storybook/vitest.setup.ts`
+
+**Storybook Config:**
+- Location: `.storybook/main.ts`
+- Story files: `../src/**/*.mdx` and `../src/**/*.stories.@(js|jsx|mjs|ts|tsx)`
+- Static assets: `../public`
+
+**Storybook Preview:**
+- Location: `.storybook/preview.ts`
+- Global styles: `../src/app/globals.css` and `./fonts.css`
+- Control matchers for props (color, date)
+- A11y test level: "todo"
+
+---
+
+*Testing analysis: 2026-04-02*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,13 @@
+{
+  "mode": "interactive",
+  "granularity": "standard",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true
+  }
+}


### PR DESCRIPTION
Been figuring out a plan for auth, so thought I'd chuck up a branch with the plan I built and solidified with get-shit-done.

Basically, the plan is to utilise better-auth to create an authentication table with a built-in client and routes. This will allow us to more easily implement stuff like SSO with google for example, or adding passkeys while using an actively maintained library, and avoiding manual JWT implementation and updates. The plan handles cases such as existing users adding authentication to their membership.

This is more of a high-level plan and is highly subject to change; details definitely need fleshing out, but as an overview, I believe this is a good position to start from.

Most important files are the `.planning/ROADMAP.md` and `.planning/PROJECT.md`