### PR TITLE
refactor(payload): rename user collection to admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "playwright": "^1.58.1",
     "storybook": "^10.2.7",
     "tailwindcss": "^4.1.18",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.0.18"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "types:generate": "payload generate:types && next typegen",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "postinstall": "lefthook install"
+    "postinstall": "lefthook install",
+    "migrate:user-admin": "tsx --env-file=.env src/scripts/user-admin-migration.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",
+    "mongodb": "^7.1.1",
     "playwright": "^1.58.1",
     "storybook": "^10.2.7",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -8288,7 +8291,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       get-tsconfig: 4.8.1
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.1.0(@vitest/browser@4.1.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.77.4)(tsx@4.21.0))(vitest@4.1.0))(vitest@4.1.0)
+      mongodb:
+        specifier: ^7.1.1
+        version: 7.1.1(@aws-sdk/credential-providers@3.984.0)
       playwright:
         specifier: ^1.58.1
         version: 1.58.2
@@ -2018,6 +2021,9 @@ packages:
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2186,6 +2192,10 @@ packages:
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
@@ -3035,6 +3045,10 @@ packages:
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
   mongodb@6.16.0:
     resolution: {integrity: sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==}
     engines: {node: '>=16.20.1'}
@@ -3046,6 +3060,33 @@ packages:
       mongodb-client-encryption: '>=6.0.0 <7'
       snappy: ^7.2.2
       socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongodb@7.1.1:
+    resolution: {integrity: sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
@@ -6466,6 +6507,10 @@ snapshots:
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.12.0
@@ -6674,6 +6719,8 @@ snapshots:
   bson-objectid@2.0.4: {}
 
   bson@6.10.4: {}
+
+  bson@7.2.0: {}
 
   buffer@4.9.2:
     dependencies:
@@ -7580,11 +7627,24 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
   mongodb@6.16.0(@aws-sdk/credential-providers@3.984.0):
     dependencies:
       '@mongodb-js/saslprep': 1.4.5
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.984.0
+
+  mongodb@7.1.1(@aws-sdk/credential-providers@3.984.0):
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.5
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.984.0
 

--- a/src/lib/slugs.ts
+++ b/src/lib/slugs.ts
@@ -6,7 +6,7 @@ export const Slugs = {
     POLAROID: "polaroid",
     REEL: "reel",
     SPONSOR: "sponsor",
-    USER: "user",
+    ADMIN: "admin",
   },
   Globals: {
     HOME_PAGE: "home-page",

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,13 +7,13 @@ import { s3Storage } from "@payloadcms/storage-s3"
 import { buildConfig } from "payload"
 import sharp from "sharp"
 import { Slugs } from "./lib/slugs"
+import { Admin } from "./payload/collections/Admin"
 import { Executive } from "./payload/collections/Executive"
 import { Media } from "./payload/collections/Media"
 import { Member } from "./payload/collections/Member"
 import { Polaroid } from "./payload/collections/Polaroid"
 import { Reel } from "./payload/collections/Reel"
 import { Sponsor } from "./payload/collections/Sponsor"
-import { User } from "./payload/collections/User"
 import { HomePage } from "./payload/globals/HomePage"
 import { PrivacyPolicy } from "./payload/globals/PrivacyPolicy"
 import { SocialLinks } from "./payload/globals/SocialLinks"
@@ -23,13 +23,13 @@ const dirname = path.dirname(filename)
 
 export default buildConfig({
   admin: {
-    user: User.slug,
+    user: Admin.slug,
     importMap: {
       baseDir: path.resolve(dirname),
       importMapFile: `${path.resolve(dirname)}/app/payload/admin/importMap.js`,
     },
   },
-  collections: [User, Media, Member, Executive, Sponsor, Reel, Polaroid],
+  collections: [Admin, Media, Member, Executive, Sponsor, Reel, Polaroid],
   globals: [HomePage, PrivacyPolicy, SocialLinks],
   editor: lexicalEditor(),
   graphQL: {

--- a/src/payload/collections/Admin.ts
+++ b/src/payload/collections/Admin.ts
@@ -1,14 +1,13 @@
 import type { CollectionConfig } from "payload"
 import { Slugs } from "@/lib/slugs"
 
-export const User: CollectionConfig = {
-  slug: Slugs.Collections.USER,
+export const Admin: CollectionConfig = {
+  slug: Slugs.Collections.ADMIN,
   admin: {
     useAsTitle: "email",
   },
   auth: true,
   fields: [
     // Email added by default
-    // Add more fields as needed
   ],
 }

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -63,11 +63,11 @@ export type SupportedTimezones =
 
 export interface Config {
   auth: {
-    user: UserAuthOperations;
+    admin: AdminAuthOperations;
   };
   blocks: {};
   collections: {
-    user: User;
+    admin: Admin;
     media: Media;
     member: Member;
     executive: Executive;
@@ -84,7 +84,7 @@ export interface Config {
   };
   collectionsJoins: {};
   collectionsSelect: {
-    user: UserSelect<false> | UserSelect<true>;
+    admin: AdminSelect<false> | AdminSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     member: MemberSelect<false> | MemberSelect<true>;
     executive: ExecutiveSelect<false> | ExecutiveSelect<true>;
@@ -117,7 +117,7 @@ export interface Config {
   widgets: {
     collections: CollectionsWidget;
   };
-  user: User;
+  user: Admin;
   jobs: {
     tasks: {
       createCollectionExport: TaskCreateCollectionExport;
@@ -130,7 +130,7 @@ export interface Config {
     workflows: unknown;
   };
 }
-export interface UserAuthOperations {
+export interface AdminAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -150,9 +150,9 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "user".
+ * via the `definition` "admin".
  */
-export interface User {
+export interface Admin {
   id: string;
   updatedAt: string;
   createdAt: string;
@@ -171,7 +171,7 @@ export interface User {
       }[]
     | null;
   password?: string | null;
-  collection: 'user';
+  collection: 'admin';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -539,8 +539,8 @@ export interface PayloadLockedDocument {
   id: string;
   document?:
     | ({
-        relationTo: 'user';
-        value: string | User;
+        relationTo: 'admin';
+        value: string | Admin;
       } | null)
     | ({
         relationTo: 'media';
@@ -568,8 +568,8 @@ export interface PayloadLockedDocument {
       } | null);
   globalSlug?: string | null;
   user: {
-    relationTo: 'user';
-    value: string | User;
+    relationTo: 'admin';
+    value: string | Admin;
   };
   updatedAt: string;
   createdAt: string;
@@ -581,8 +581,8 @@ export interface PayloadLockedDocument {
 export interface PayloadPreference {
   id: string;
   user: {
-    relationTo: 'user';
-    value: string | User;
+    relationTo: 'admin';
+    value: string | Admin;
   };
   key?: string | null;
   value?:
@@ -610,9 +610,9 @@ export interface PayloadMigration {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "user_select".
+ * via the `definition` "admin_select".
  */
-export interface UserSelect<T extends boolean = true> {
+export interface AdminSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -948,7 +948,16 @@ export interface TaskCreateCollectionExport {
     id: string;
     name: string;
     batchSize?: number | null;
-    collectionSlug: 'user' | 'media' | 'member' | 'executive' | 'sponsor' | 'reel' | 'polaroid' | 'exports' | 'imports';
+    collectionSlug:
+      | 'admin'
+      | 'media'
+      | 'member'
+      | 'executive'
+      | 'sponsor'
+      | 'reel'
+      | 'polaroid'
+      | 'exports'
+      | 'imports';
     drafts?: ('yes' | 'no') | null;
     exportCollection: string;
     fields?: string[] | null;

--- a/src/scripts/user-admin-migration.ts
+++ b/src/scripts/user-admin-migration.ts
@@ -1,0 +1,28 @@
+import { MongoClient } from "mongodb"
+
+const uri = process.env.DATABASE_URI
+if (!uri) throw new Error("DATABASE_URI is not set")
+
+const client = new MongoClient(uri)
+try {
+  await client.connect()
+  const db = client.db()
+
+  const [usersCol, adminsCol] = await Promise.all([
+    db.listCollections({ name: "users" }).toArray(),
+    db.listCollections({ name: "admins" }).toArray(),
+  ])
+
+  if (usersCol.length === 0) {
+    console.log("No 'users' collection found — nothing to rename.")
+  } else if (adminsCol.length !== 0) {
+    console.log("'admins' collection already exists — migration already applied.")
+  } else {
+    await db.collection("users").rename("admins")
+    console.log("Renamed 'users' collection to 'admins'.")
+  }
+} catch (error) {
+  console.error("An error occurred during the migration:", error)
+} finally {
+  await client.close()
+}


### PR DESCRIPTION
# Description

This PR renames the `User` Payload collection to `Admin` and introduces a MongoDB migration script to rename the existing `users` database collection to `admins`.

- renames `src/payload/collections/User.ts` to `Admin.ts`, updating the collection slug from `user` to `admin`
- updates `Slugs.Collections.USER` to `Slugs.Collections.ADMIN` in `src/lib/slugs.ts`
- updates `payload.config.ts` to import and register the `Admin` collection in place of `User`
- adds `src/scripts/user-admin-migration.ts` — a one-shot migration script that renames the `users` MongoDB collection to `admins`, with guards to skip if already migrated or if the source collection doesn't exist
- adds `migrate:user-admin` script to `package.json` to run the migration via `tsx`
- installs `mongodb` and `tsx` as dev dependencies to support the migration script

Closes #250

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member