### PR TITLE
fix(dockerfile): mount auth secrets required for better auth build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN --mount=type=secret,id=DATABASE_URI \
     --mount=type=secret,id=S3_SECRET_ACCESS_KEY \
     --mount=type=secret,id=S3_REGION \
     --mount=type=secret,id=S3_BUCKET \
+    --mount=type=secret,id=NODE_ENV \
+    --mount=type=secret,id=BETTER_AUTH_SECRET \
     sh -c 'export DATABASE_URI=$(cat /run/secrets/DATABASE_URI) && \
            export PAYLOAD_SECRET=$(cat /run/secrets/PAYLOAD_SECRET) && \
            export NEXT_PUBLIC_URL=$(cat /run/secrets/NEXT_PUBLIC_URL) && \


### PR DESCRIPTION
# Description
This PR fixes the Docker build by mounting the `NODE_ENV` and `BETTER_AUTH_SECRET` secrets that are required during the `pnpm run build` step introduced by the Better Auth integration.

- adds `--mount=type=secret,id=NODE_ENV` to the build stage's secret mounts
- adds `--mount=type=secret,id=BETTER_AUTH_SECRET` to the build stage's secret mounts
- exports both secrets as environment variables so they are available during the build

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Verified that the Docker build completes successfully with the new secret mounts in place.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member