### PR TITLE
feat(api): integrate Better Auth into sign-up flow with rollback and security hardening

### DIFF
--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -1,23 +1,17 @@
-import { ValidationError } from "payload"
-import { payload } from "@/lib/payload"
-import { createMemberSchema } from "@/types/schemas/member"
+import { AuthService, DuplicateFieldError } from "@/services/auth.service"
 
 export async function POST(request: Request) {
-  const member = createMemberSchema.parse(await request.json())
+  const authService = new AuthService()
 
   try {
-    const createdMember = await payload.create({
-      collection: "member",
-      data: member,
-    })
+    const data = await request.json()
+    const createdMember = await authService.signUpPayloadMember(data)
     return new Response(JSON.stringify(createdMember), { status: 201 })
   } catch (err) {
-    if (
-      err instanceof ValidationError &&
-      err.data?.errors?.some((e) => e.message === "Value must be unique")
-    ) {
-      const field = err.data.errors.find((e) => e.message === "Value must be unique")?.path
-      return new Response(JSON.stringify({ error: "Value already in use", field }), { status: 409 })
+    if (err instanceof DuplicateFieldError) {
+      return new Response(JSON.stringify({ error: "Value already in use", field: err.field }), {
+        status: 409,
+      })
     }
     throw err
   }

--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -30,8 +30,15 @@ export async function POST(request: Request) {
 
     return new Response(JSON.stringify(member), { status: 201 })
   } catch (err) {
+    if (err instanceof SyntaxError) {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 })
+    }
     if (err instanceof ZodError) {
-      return new Response(JSON.stringify({ error: err.issues }), { status: 400 })
+      const fieldErrors = err.issues.map((issue) => ({
+        field: issue.path.join("."),
+        message: issue.message,
+      }))
+      return new Response(JSON.stringify({ error: fieldErrors }), { status: 400 })
     }
     if (err instanceof DuplicateFieldError) {
       return new Response(JSON.stringify({ error: "Value already in use", field: err.field }), {

--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -1,17 +1,45 @@
-import { AuthService, DuplicateFieldError } from "@/services/auth.service"
+import { ZodError } from "zod"
+import { payload } from "@/lib/payload"
+import { Slugs } from "@/lib/slugs"
+import { AuthService, BetterAuthSignUpError, DuplicateFieldError } from "@/services/auth.service"
+import { signUpSchema } from "@/types/schemas/sign-up"
 
 export async function POST(request: Request) {
   const authService = new AuthService()
 
   try {
-    const data = await request.json()
-    const createdMember = await authService.signUpPayloadMember(data)
-    return new Response(JSON.stringify(createdMember), { status: 201 })
+    const body = await request.json()
+    const { password, ...memberData } = signUpSchema.parse(body)
+
+    const existing = await payload.find({
+      collection: Slugs.Collections.MEMBER,
+      where: { email: { equals: memberData.email } },
+      limit: 1,
+    })
+
+    const baUser = await authService.signUpBetterAuth({
+      name: `${memberData.firstName} ${memberData.lastName}`,
+      email: memberData.email,
+      password,
+    })
+
+    const member =
+      existing.docs.length > 0
+        ? await authService.linkExistingMember(memberData.email, baUser.id)
+        : await authService.signUpPayloadMember(memberData, baUser.id)
+
+    return new Response(JSON.stringify(member), { status: 201 })
   } catch (err) {
+    if (err instanceof ZodError) {
+      return new Response(JSON.stringify({ error: err.issues }), { status: 400 })
+    }
     if (err instanceof DuplicateFieldError) {
       return new Response(JSON.stringify({ error: "Value already in use", field: err.field }), {
         status: 409,
       })
+    }
+    if (err instanceof BetterAuthSignUpError) {
+      return new Response(JSON.stringify({ error: "Email already registered" }), { status: 409 })
     }
     throw err
   }

--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -1,7 +1,7 @@
 import { ZodError } from "zod"
 import { payload } from "@/lib/payload"
 import { Slugs } from "@/lib/slugs"
-import { AuthService, BetterAuthSignUpError, DuplicateFieldError } from "@/services/auth.service"
+import { AuthService, DuplicateFieldError } from "@/services/auth.service"
 import { signUpSchema } from "@/types/schemas/sign-up"
 
 export async function POST(request: Request) {
@@ -38,9 +38,7 @@ export async function POST(request: Request) {
         status: 409,
       })
     }
-    if (err instanceof BetterAuthSignUpError) {
-      return new Response(JSON.stringify({ error: "Email already registered" }), { status: 409 })
-    }
+    console.error("[POST /api/sign-up] Unhandled error", { error: err })
     throw err
   }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -22,15 +22,19 @@ export class BetterAuthSignUpError extends Error {
 }
 
 export class AuthService {
-  public async signUpPayloadMember(data: Response["json"]): Promise<Member> {
+  public async signUpPayloadMember(
+    data: CreateMemberInput,
+    betterAuthUserId: string,
+  ): Promise<Member> {
     const memberData = createMemberSchema.parse(data)
 
     try {
       return await payload.create({
         collection: Slugs.Collections.MEMBER,
-        data: memberData,
+        data: { ...memberData, betterAuthUserId },
       })
     } catch (err) {
+      await this.rollbackBetterAuthSignUp(betterAuthUserId)
       if (
         err instanceof ValidationError &&
         err.data?.errors?.some((e) => e.message === "Value must be unique")
@@ -68,6 +72,7 @@ export class AuthService {
       })
       return result.docs[0]
     } catch (err) {
+      await this.rollbackBetterAuthSignUp(betterAuthUserId)
       throw err
     }
   }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,5 @@
 import type { User } from "better-auth"
+import { isAPIError } from "better-auth/utils"
 import { ValidationError } from "payload"
 import { auth } from "@/lib/auth"
 import { payload } from "@/lib/payload"
@@ -15,9 +16,10 @@ export class DuplicateFieldError extends Error {
 }
 
 export class BetterAuthSignUpError extends Error {
-  constructor() {
+  constructor(cause?: unknown) {
     super("Better Auth sign up failed")
     this.name = "BetterAuthSignUpError"
+    if (cause !== undefined) this.cause = cause
   }
 }
 
@@ -53,8 +55,15 @@ export class AuthService {
         body: signUpData,
       })
       return result.user
-    } catch {
-      throw new BetterAuthSignUpError()
+    } catch (err) {
+      if (isAPIError(err) && err.body?.code === "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL") {
+        throw new DuplicateFieldError("email")
+      }
+      console.error("[AuthService] signUpBetterAuth unexpected error", {
+        email: data.email,
+        error: err,
+      })
+      throw new BetterAuthSignUpError(err)
     }
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -81,6 +81,17 @@ export class AuthService {
 
   public async linkExistingMember(email: string, betterAuthUserId: string): Promise<Member> {
     try {
+      const existing = await payload.find({
+        collection: Slugs.Collections.MEMBER,
+        where: { email: { equals: email }, betterAuthUserId: { exists: false } },
+        limit: 1,
+      })
+
+      if (existing.docs.length === 0) {
+        await this.rollbackBetterAuthSignUp(betterAuthUserId)
+        throw new DuplicateFieldError("email")
+      }
+
       const result = await payload.update({
         collection: Slugs.Collections.MEMBER,
         where: { email: { equals: email } },
@@ -88,7 +99,9 @@ export class AuthService {
       })
       return result.docs[0]
     } catch (err) {
-      await this.rollbackBetterAuthSignUp(betterAuthUserId)
+      if (!(err instanceof DuplicateFieldError)) {
+        await this.rollbackBetterAuthSignUp(betterAuthUserId)
+      }
       throw err
     }
   }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -44,6 +44,10 @@ export class AuthService {
         const field = err.data.errors.find((e) => e.message === "Value must be unique")?.path ?? ""
         throw new DuplicateFieldError(field)
       }
+      console.error("[AuthService] signUpPayloadMember failed, Better Auth user rolled back", {
+        betterAuthUserId,
+        error: err,
+      })
       throw err
     }
   }
@@ -70,6 +74,7 @@ export class AuthService {
   public async rollbackBetterAuthSignUp(userId: string): Promise<void> {
     try {
       const context = await auth.$context
+      await context.internalAdapter.deleteAccounts(userId)
       await context.internalAdapter.deleteUser(userId)
     } catch (err) {
       console.error(
@@ -80,6 +85,8 @@ export class AuthService {
   }
 
   public async linkExistingMember(email: string, betterAuthUserId: string): Promise<Member> {
+    let alreadyRolledBack = false
+
     try {
       const existing = await payload.find({
         collection: Slugs.Collections.MEMBER,
@@ -88,18 +95,31 @@ export class AuthService {
       })
 
       if (existing.docs.length === 0) {
+        alreadyRolledBack = true
         await this.rollbackBetterAuthSignUp(betterAuthUserId)
         throw new DuplicateFieldError("email")
       }
 
       const result = await payload.update({
         collection: Slugs.Collections.MEMBER,
-        where: { email: { equals: email } },
+        where: { email: { equals: email }, betterAuthUserId: { exists: false } },
         data: { betterAuthUserId },
       })
+
+      if (result.docs.length === 0) {
+        alreadyRolledBack = true
+        await this.rollbackBetterAuthSignUp(betterAuthUserId)
+        throw new DuplicateFieldError("email")
+      }
+
       return result.docs[0]
     } catch (err) {
-      if (!(err instanceof DuplicateFieldError)) {
+      if (!alreadyRolledBack) {
+        console.error("[AuthService] linkExistingMember failed, rolling back Better Auth user", {
+          email,
+          betterAuthUserId,
+          error: err,
+        })
         await this.rollbackBetterAuthSignUp(betterAuthUserId)
       }
       throw err

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,13 +1,22 @@
+import type { User } from "better-auth"
 import { ValidationError } from "payload"
+import { auth } from "@/lib/auth"
 import { payload } from "@/lib/payload"
 import type { Member } from "@/payload/payload-types"
-import { createMemberSchema } from "@/types/schemas/member"
-import { Slugs } from "./../lib/slugs"
+import { type CreateMemberInput, createMemberSchema } from "@/types/schemas/member"
+import { type CreateUserInput, createUserSchema } from "@/types/schemas/user"
 
 export class DuplicateFieldError extends Error {
   constructor(public readonly field: string) {
     super("Value already in use")
     this.name = "DuplicateFieldError"
+  }
+}
+
+export class BetterAuthSignUpError extends Error {
+  constructor() {
+    super("Better Auth sign up failed")
+    this.name = "BetterAuthSignUpError"
   }
 }
 
@@ -29,6 +38,18 @@ export class AuthService {
         throw new DuplicateFieldError(field)
       }
       throw err
+    }
+  }
+
+  public async signUpBetterAuth(data: CreateUserInput): Promise<User> {
+    const signUpData = createUserSchema.parse(data)
+    try {
+      const result = await auth.api.signUpEmail({
+        body: signUpData,
+      })
+      return result.user
+    } catch {
+      throw new BetterAuthSignUpError()
     }
   }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -52,4 +52,9 @@ export class AuthService {
       throw new BetterAuthSignUpError()
     }
   }
+
+  public async rollbackBetterAuthSignUp(userId: string): Promise<void> {
+    const context = await auth.$context
+    await context.internalAdapter.deleteUser(userId)
+  }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,34 @@
+import { ValidationError } from "payload"
+import { payload } from "@/lib/payload"
+import type { Member } from "@/payload/payload-types"
+import { createMemberSchema } from "@/types/schemas/member"
+import { Slugs } from "./../lib/slugs"
+
+export class DuplicateFieldError extends Error {
+  constructor(public readonly field: string) {
+    super("Value already in use")
+    this.name = "DuplicateFieldError"
+  }
+}
+
+export class AuthService {
+  public async signUpPayloadMember(data: Response["json"]): Promise<Member> {
+    const memberData = createMemberSchema.parse(data)
+
+    try {
+      return await payload.create({
+        collection: Slugs.Collections.MEMBER,
+        data: memberData,
+      })
+    } catch (err) {
+      if (
+        err instanceof ValidationError &&
+        err.data?.errors?.some((e) => e.message === "Value must be unique")
+      ) {
+        const field = err.data.errors.find((e) => e.message === "Value must be unique")?.path ?? ""
+        throw new DuplicateFieldError(field)
+      }
+      throw err
+    }
+  }
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,5 @@
 import type { User } from "better-auth"
-import { isAPIError } from "better-auth/utils"
+import { isAPIError } from "better-auth/api"
 import { ValidationError } from "payload"
 import { auth } from "@/lib/auth"
 import { payload } from "@/lib/payload"
@@ -68,8 +68,15 @@ export class AuthService {
   }
 
   public async rollbackBetterAuthSignUp(userId: string): Promise<void> {
-    const context = await auth.$context
-    await context.internalAdapter.deleteUser(userId)
+    try {
+      const context = await auth.$context
+      await context.internalAdapter.deleteUser(userId)
+    } catch (err) {
+      console.error(
+        "[AuthService] CRITICAL: Failed to rollback Better Auth user. Record leaked and requires manual cleanup.",
+        { betterAuthUserId: userId, error: err },
+      )
+    }
   }
 
   public async linkExistingMember(email: string, betterAuthUserId: string): Promise<Member> {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -2,6 +2,7 @@ import type { User } from "better-auth"
 import { ValidationError } from "payload"
 import { auth } from "@/lib/auth"
 import { payload } from "@/lib/payload"
+import { Slugs } from "@/lib/slugs"
 import type { Member } from "@/payload/payload-types"
 import { type CreateMemberInput, createMemberSchema } from "@/types/schemas/member"
 import { type CreateUserInput, createUserSchema } from "@/types/schemas/user"
@@ -56,5 +57,18 @@ export class AuthService {
   public async rollbackBetterAuthSignUp(userId: string): Promise<void> {
     const context = await auth.$context
     await context.internalAdapter.deleteUser(userId)
+  }
+
+  public async linkExistingMember(email: string, betterAuthUserId: string): Promise<Member> {
+    try {
+      const result = await payload.update({
+        collection: Slugs.Collections.MEMBER,
+        where: { email: { equals: email } },
+        data: { betterAuthUserId },
+      })
+      return result.docs[0]
+    } catch (err) {
+      throw err
+    }
   }
 }

--- a/src/types/schemas/member.ts
+++ b/src/types/schemas/member.ts
@@ -39,3 +39,5 @@ export const createMemberSchema = memberSchema
       })
     }
   })
+
+export type CreateMemberInput = z.infer<typeof createMemberSchema>

--- a/src/types/schemas/sign-up.ts
+++ b/src/types/schemas/sign-up.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+import { createMemberSchema } from "@/types/schemas/member"
+
+export const signUpSchema = createMemberSchema.extend({
+  password: z.string().min(8, "Password must be at least 8 characters"),
+})

--- a/src/types/schemas/user.ts
+++ b/src/types/schemas/user.ts
@@ -1,0 +1,20 @@
+import type { User } from "better-auth"
+import { z } from "zod"
+
+export const createUserSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.email({ error: "Please enter a valid email" }),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+}) satisfies z.ZodType<Partial<User>>
+
+export type CreateUserInput = z.infer<typeof createUserSchema>
+
+export const userSchema = z.object({
+  id: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  email: z.email(),
+  emailVerified: z.boolean(),
+  name: z.string().min(2).max(100),
+  image: z.url().optional().nullable(),
+}) satisfies z.ZodType<User>

--- a/src/types/schemas/user.ts
+++ b/src/types/schemas/user.ts
@@ -4,7 +4,7 @@ import { z } from "zod"
 export const createUserSchema = z.object({
   name: z.string().min(1, "Name is required"),
   email: z.email({ error: "Please enter a valid email" }),
-  password: z.string().min(6, "Password must be at least 6 characters"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
 }) satisfies z.ZodType<Partial<User>>
 
 export type CreateUserInput = z.infer<typeof createUserSchema>


### PR DESCRIPTION
# Description
This PR integrates Better Auth into the sign-up API flow, introducing a dedicated `AuthService` class that handles user creation across both Better Auth and Payload CMS, with rollback on failure and protection against account takeover.

- adds `AuthService` with three core methods: `signUpBetterAuth`, `signUpPayloadMember`, and `linkExistingMember`
- adds `rollbackBetterAuthSignUp` to delete the Better Auth user if the Payload member creation step fails, preventing leaked auth records
- adds `linkExistingMember` to handle the case where a Payload member already exists for the given email, linking them to the new Better Auth account rather than creating a duplicate
  - rolls back the Better Auth user if no linkable member is found or if the update is a no-op (i.e. a race condition swapped in another `betterAuthUserId` between find and update)
- adds `DuplicateFieldError` and `BetterAuthSignUpError` custom error classes for structured error propagation
- refactors `POST /api/sign-up` to delegate auth logic to `AuthService` and removes the old inline Payload-only sign-up logic
- improves sign-up route error responses to return structured `ZodError` field errors, a `DuplicateFieldError` 409, and a `SyntaxError` 400 for malformed JSON bodies
- adds `signUpSchema`, `createUserSchema` and `userSchema` schemas

Closes #253

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
