### PR TITLE
feat(payload): add combined member and auth delete button in admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@payloadcms/plugin-import-export": "3.80.0",
     "@payloadcms/richtext-lexical": "3.80.0",
     "@payloadcms/storage-s3": "3.80.0",
+    "@payloadcms/ui": "3.80.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "better-auth": "^1.6.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@payloadcms/storage-s3':
         specifier: 3.80.0
         version: 3.80.0(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(payload@3.80.0(graphql@16.13.1)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@payloadcms/ui':
+        specifier: 3.80.0
+        version: 3.80.0(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(payload@3.80.0(graphql@16.13.1)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,33 @@
+import { auth } from "@/lib/auth"
+import { payload } from "@/lib/payload"
+import { Slugs } from "@/lib/slugs"
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { user } = await payload.auth({ headers: request.headers })
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
+  }
+
+  const { id } = await params
+
+  try {
+    const member = await payload.findByID({ collection: Slugs.Collections.MEMBER, id })
+
+    if (!member) {
+      return new Response(JSON.stringify({ error: "Member not found" }), { status: 404 })
+    }
+
+    if (member.betterAuthUserId) {
+      const context = await auth.$context
+      await context.internalAdapter.deleteAccounts(member.betterAuthUserId)
+      await context.internalAdapter.deleteUser(member.betterAuthUserId)
+    }
+
+    await payload.delete({ collection: Slugs.Collections.MEMBER, id })
+
+    return new Response(null, { status: 204 })
+  } catch (err) {
+    console.error("[DELETE /api/admin/members/:id] Unhandled error", { id, error: err })
+    throw err
+  }
+}

--- a/src/app/payload/admin/importMap.js
+++ b/src/app/payload/admin/importMap.js
@@ -1,5 +1,6 @@
 import { ExportListMenuItem as ExportListMenuItem_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { ImportListMenuItem as ImportListMenuItem_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
+import { DeleteMemberButton as DeleteMemberButton_c90e8366f3761744871430cc8274e250 } from '@/payload/components/DeleteMemberButton'
 import { FormatField as FormatField_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { LimitField as LimitField_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
 import { Page as Page_cdf7e044479f899a31f804427d568b36 } from '@payloadcms/plugin-import-export/rsc'
@@ -19,6 +20,7 @@ import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 export const importMap = {
   "@payloadcms/plugin-import-export/rsc#ExportListMenuItem": ExportListMenuItem_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#ImportListMenuItem": ImportListMenuItem_cdf7e044479f899a31f804427d568b36,
+  "@/payload/components/DeleteMemberButton#DeleteMemberButton": DeleteMemberButton_c90e8366f3761744871430cc8274e250,
   "@payloadcms/plugin-import-export/rsc#FormatField": FormatField_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#LimitField": LimitField_cdf7e044479f899a31f804427d568b36,
   "@payloadcms/plugin-import-export/rsc#Page": Page_cdf7e044479f899a31f804427d568b36,

--- a/src/app/payload/custom.scss
+++ b/src/app/payload/custom.scss
@@ -1,0 +1,5 @@
+.btn--delete {
+  --bg-color: var(--theme-error-500) !important;
+  --hover-bg: var(--theme-error-400) !important;
+  --color: white !important;
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -10,6 +10,9 @@ export const Routes = {
 export type Route = (typeof Routes)[keyof typeof Routes]
 
 export const ApiRoutes = {
+  ADMIN: {
+    MEMBERS: (id: string) => `/api/admin/members/${id}`,
+  } as const,
   SIGN_UP: "/api/sign-up",
   HEALTH: "/api/health",
   OG: "/og",

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -11,7 +11,7 @@ export type Route = (typeof Routes)[keyof typeof Routes]
 
 export const ApiRoutes = {
   ADMIN: {
-    MEMBERS: (id: string) => `/api/admin/members/${id}`,
+    MEMBERS: (id: string | number | undefined) => `/api/admin/members/${id ?? ""}`,
   } as const,
   SIGN_UP: "/api/sign-up",
   HEALTH: "/api/health",

--- a/src/payload/collections/Member.ts
+++ b/src/payload/collections/Member.ts
@@ -5,6 +5,11 @@ export const Member: CollectionConfig = {
   slug: Slugs.Collections.MEMBER,
   admin: {
     useAsTitle: "email",
+    components: {
+      edit: {
+        beforeDocumentControls: ["@/payload/components/DeleteMemberButton#DeleteMemberButton"],
+      },
+    },
   },
   fields: [
     {

--- a/src/payload/components/DeleteMemberButton.tsx
+++ b/src/payload/components/DeleteMemberButton.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { Button, useDocumentInfo } from "@payloadcms/ui"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { ApiRoutes } from "@/lib/routes"
+
+export function DeleteMemberButton() {
+  const { id } = useDocumentInfo()
+  const router = useRouter()
+  const [confirming, setConfirming] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete() {
+    if (!id) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch(ApiRoutes.ADMIN.MEMBERS(id), { method: "DELETE" })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? `Delete failed (${res.status})`)
+        setConfirming(false)
+        return
+      }
+      router.push("/payload/admin/collections/member")
+    } catch {
+      setError("Unexpected error — please try again")
+      setConfirming(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (confirming) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span style={{ fontSize: "13px" }}>Delete member and auth user?</span>
+        <Button
+          buttonStyle="primary"
+          className="btn--delete"
+          disabled={loading}
+          onClick={handleDelete}
+          size="small"
+        >
+          {loading ? "Deleting…" : "Yes, delete"}
+        </Button>
+        <Button
+          buttonStyle="secondary"
+          disabled={loading}
+          onClick={() => setConfirming(false)}
+          size="small"
+        >
+          Cancel
+        </Button>
+        {error && (
+          <span style={{ color: "var(--theme-error-500)", fontSize: "13px" }}>{error}</span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Button
+      buttonStyle="primary"
+      className="btn--delete"
+      onClick={() => setConfirming(true)}
+      size="small"
+    >
+      Delete with Auth
+    </Button>
+  )
+}


### PR DESCRIPTION
# Description

This PR adds a custom `DeleteMemberButton` component to the Payload admin panel that deletes a member record and its associated Better Auth user in a single action.

- adds `DELETE /api/admin/members/:id` route that removes the Payload member document and cascades deletion to the linked Better Auth accounts and user via `internalAdapter`
- adds `DeleteMemberButton` client component with a two-step confirm flow (initial button → confirm/cancel) to prevent accidental deletes
- registers `DeleteMemberButton` in the `Member` collection's `beforeDocumentControls` admin slot and the Payload `importMap`
- adds `ApiRoutes.ADMIN.MEMBERS` helper to `routes.ts` for the delete endpoint
- adds `@payloadcms/ui` dependency for `Button` and `useDocumentInfo` hooks used in the component
- adds `.btn--delete` CSS override in `custom.scss` to style the button with the error colour tokens

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

### How to test

Navigate to `/payload/admin/collections/member` and open any member document. A red "Delete with Auth" button will appear in the document controls area. Click it to trigger the confirmation prompt, then confirm — the member and their auth user should be removed and you should be redirected back to the member list.

To verify the auth user is also deleted, check the Better Auth `user` and `account` tables before and after the action to confirm the rows are gone.