### PR TITLE
feat(navbar): make navbar session-aware with login and logout controls

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,9 +1,11 @@
 import localFont from "next/font/local"
+import { headers } from "next/headers"
 import type React from "react"
 import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
+import { auth } from "@/lib/auth"
 import { getSocialLinks } from "@/lib/helpers"
 import { ApiRoutes, Routes } from "@/lib/routes"
 
@@ -80,7 +82,10 @@ const navbarLinks: { label: string; href: string }[] = [
 export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 
-  const socialLinks = await getSocialLinks()
+  const [socialLinks, session] = await Promise.all([
+    getSocialLinks(),
+    auth.api.getSession({ headers: await headers() }),
+  ])
 
   return (
     <html
@@ -90,7 +95,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
         <Toaster />
         <div className="mx-auto flex w-full max-w-[1480px] grow flex-col gap-14 px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-          <Navbar links={navbarLinks} socialLinks={socialLinks} />
+          <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
           <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
         </div>
         <Footer links={navbarLinks} socialLinks={socialLinks} />

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -113,19 +113,6 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
               ))}
             </div>
             <div className="flex flex-col items-center gap-4">
-              {!isPending &&
-                (session ? (
-                  <Dropdown
-                    label={session.user.name.split(" ")[0].toUpperCase()}
-                    options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
-                    theme="dark"
-                    triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
-                  />
-                ) : (
-                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
-                    <Button theme="primary">Log In</Button>
-                  </Link>
-                ))}
               <Link
                 className="grid grid-cols-4"
                 href={Routes.SIGN_UP}
@@ -139,6 +126,19 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                 <div className="h-0.5 w-full bg-purple-400" />
                 <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
               </Link>
+              {!isPending &&
+                (session ? (
+                  <Dropdown
+                    label={session.user.name.split(" ")[0].toUpperCase()}
+                    options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
+                    theme="dark"
+                    triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
+                  />
+                ) : (
+                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
+                    <Button theme="primary">Log In</Button>
+                  </Link>
+                ))}
             </div>
           </motion.div>
         )}

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -20,9 +20,10 @@ import { mobileNavbarVariants } from "./variants"
  * @param links Links to be displayed in the mobile navbar.
  * @param socialLinks Social links to be displayed in the mobile navbar.
  */
-export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
+export const MobileNavbar = ({ links, socialLinks, initialSession }: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false)
-  const { data: session, isPending } = authClient.useSession()
+  const { data: hookSession, isPending } = authClient.useSession()
+  const session = isPending ? initialSession : hookSession
   const router = useRouter()
 
   const handleLogout = async () => {
@@ -113,34 +114,33 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
               ))}
             </div>
             <div className="flex flex-col items-center gap-4">
-              {!isPending &&
-                (session ? (
-                  <div className="flex flex-row items-center gap-2">
-                    <Button theme="dark">{session.user.name.split(" ")[0].toUpperCase()}</Button>
-                    <Button onClick={handleLogout} theme="dark">
-                      Logout
+              {session ? (
+                <div className="flex flex-row items-center gap-2">
+                  <Button theme="dark">{session.user.name.split(" ")[0].toUpperCase()}</Button>
+                  <Button onClick={handleLogout} theme="dark">
+                    Logout
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <Link
+                    className="grid grid-cols-4"
+                    href={Routes.SIGN_UP}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    <Button className="col-span-4 rounded-b-none" theme="dark">
+                      Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
                     </Button>
-                  </div>
-                ) : (
-                  <>
-                    <Link
-                      className="grid grid-cols-4"
-                      href={Routes.SIGN_UP}
-                      onClick={() => setIsOpen(false)}
-                    >
-                      <Button className="col-span-4 rounded-b-none" theme="dark">
-                        Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
-                      </Button>
-                      <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
-                      <div className="h-0.5 w-full bg-blue-400" />
-                      <div className="h-0.5 w-full bg-purple-400" />
-                      <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
-                    </Link>
-                    <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
-                      <Button theme="primary">Log In</Button>
-                    </Link>
-                  </>
-                ))}
+                    <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+                    <div className="h-0.5 w-full bg-blue-400" />
+                    <div className="h-0.5 w-full bg-purple-400" />
+                    <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
+                  </Link>
+                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
+                    <Button theme="primary">Log In</Button>
+                  </Link>
+                </>
+              )}
             </div>
           </motion.div>
         )}

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -7,7 +7,7 @@ import Image from "next/image"
 import Link, { type LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
-import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
+import { BorderButton, Button, Dropdown, Heading, SocialIcon } from "@/components/Primitive"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
@@ -115,12 +115,11 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
             {!isPending &&
               (session ? (
                 <div className="flex w-full flex-col items-center gap-3 px-4">
-                  <Button className="w-full" onClick={handleLogout} theme="dark">
-                    Logout <ArrowRightIcon className="h-3 w-3" />
-                  </Button>
-                  <span className="paragraph-sm text-gray-700 uppercase">
-                    {session.user.name.split(" ")[0]}
-                  </span>
+                  <Dropdown
+                    label={session.user.name.split(" ")[0].toUpperCase()}
+                    options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
+                    theme="dark"
+                  />
                 </div>
               ) : (
                 <div className="flex w-full flex-col">

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -119,6 +119,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                     label={session.user.name.split(" ")[0].toUpperCase()}
                     options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
                     theme="dark"
+                    triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
                   />
                 </div>
               ) : (

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -112,36 +112,34 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                 </a>
               ))}
             </div>
-            {!isPending &&
-              (session ? (
-                <div className="flex w-full flex-col items-center gap-3 px-4">
+            <div className="flex flex-col items-center gap-4">
+              {!isPending &&
+                (session ? (
                   <Dropdown
                     label={session.user.name.split(" ")[0].toUpperCase()}
                     options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
                     theme="dark"
                     triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
                   />
-                </div>
-              ) : (
-                <div className="flex flex-col items-center gap-4">
+                ) : (
                   <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
                     <Button theme="primary">Log In</Button>
                   </Link>
-                  <Link
-                    className="grid grid-cols-4"
-                    href={Routes.SIGN_UP}
-                    onClick={() => setIsOpen(false)}
-                  >
-                    <Button className="col-span-4 rounded-b-none" theme="dark">
-                      Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
-                    </Button>
-                    <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
-                    <div className="h-0.5 w-full bg-blue-400" />
-                    <div className="h-0.5 w-full bg-purple-400" />
-                    <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
-                  </Link>
-                </div>
-              ))}
+                ))}
+              <Link
+                className="grid grid-cols-4"
+                href={Routes.SIGN_UP}
+                onClick={() => setIsOpen(false)}
+              >
+                <Button className="col-span-4 rounded-b-none" theme="dark">
+                  Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
+                </Button>
+                <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+                <div className="h-0.5 w-full bg-blue-400" />
+                <div className="h-0.5 w-full bg-purple-400" />
+                <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
+              </Link>
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -115,12 +115,12 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
             {!isPending &&
               (session ? (
                 <div className="flex w-full flex-col items-center gap-3 px-4">
-                  <span className="paragraph-sm text-gray-700">
-                    Signed in as <span className="font-semibold">{session.user.name}</span>
-                  </span>
                   <Button className="w-full" onClick={handleLogout} theme="dark">
                     Logout <ArrowRightIcon className="h-3 w-3" />
                   </Button>
+                  <span className="paragraph-sm text-gray-700 uppercase">
+                    {session.user.name.split(" ")[0]}
+                  </span>
                 </div>
               ) : (
                 <div className="flex w-full flex-col">

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -122,11 +122,9 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                   />
                 </div>
               ) : (
-                <div className="flex w-full flex-col">
+                <div className="flex flex-col items-center gap-4">
                   <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
-                    <Button className="w-full rounded-none" theme="primary">
-                      Log In
-                    </Button>
+                    <Button theme="primary">Log In</Button>
                   </Link>
                   <Link
                     className="grid grid-cols-4"

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -7,7 +7,7 @@ import Image from "next/image"
 import Link, { type LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
-import { BorderButton, Button, Dropdown, Heading, SocialIcon } from "@/components/Primitive"
+import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
@@ -113,31 +113,33 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
               ))}
             </div>
             <div className="flex flex-col items-center gap-4">
-              <Link
-                className="grid grid-cols-4"
-                href={Routes.SIGN_UP}
-                onClick={() => setIsOpen(false)}
-              >
-                <Button className="col-span-4 rounded-b-none" theme="dark">
-                  Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
-                </Button>
-                <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
-                <div className="h-0.5 w-full bg-blue-400" />
-                <div className="h-0.5 w-full bg-purple-400" />
-                <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
-              </Link>
               {!isPending &&
                 (session ? (
-                  <Dropdown
-                    label={session.user.name.split(" ")[0].toUpperCase()}
-                    options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
-                    theme="dark"
-                    triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
-                  />
+                  <div className="flex flex-row items-center gap-2">
+                    <Button theme="dark">{session.user.name.split(" ")[0].toUpperCase()}</Button>
+                    <Button onClick={handleLogout} theme="dark">
+                      Logout
+                    </Button>
+                  </div>
                 ) : (
-                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
-                    <Button theme="primary">Log In</Button>
-                  </Link>
+                  <>
+                    <Link
+                      className="grid grid-cols-4"
+                      href={Routes.SIGN_UP}
+                      onClick={() => setIsOpen(false)}
+                    >
+                      <Button className="col-span-4 rounded-b-none" theme="dark">
+                        Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
+                      </Button>
+                      <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+                      <div className="h-0.5 w-full bg-blue-400" />
+                      <div className="h-0.5 w-full bg-purple-400" />
+                      <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
+                    </Link>
+                    <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
+                      <Button theme="primary">Log In</Button>
+                    </Link>
+                  </>
                 ))}
             </div>
           </motion.div>

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -5,8 +5,10 @@ import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion } from "motion/react"
 import Image from "next/image"
 import Link, { type LinkProps } from "next/link"
+import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
+import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
 import type { NavbarProps } from "../Navbar"
@@ -20,6 +22,15 @@ import { mobileNavbarVariants } from "./variants"
  */
 export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const { data: session, isPending } = authClient.useSession()
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    setIsOpen(false)
+    await authClient.signOut()
+    router.push(Routes.HOME)
+    router.refresh()
+  }
 
   useEffect(() => {
     const handleResize = () => {
@@ -101,15 +112,38 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                 </a>
               ))}
             </div>
-            <Link className="grid grid-cols-4" href={Routes.SIGN_UP}>
-              <Button className="col-span-4 rounded-b-none" theme="dark">
-                Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
-              </Button>
-              <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
-              <div className="h-0.5 w-full bg-blue-400" />
-              <div className="h-0.5 w-full bg-purple-400" />
-              <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
-            </Link>
+            {!isPending &&
+              (session ? (
+                <div className="flex w-full flex-col items-center gap-3 px-4">
+                  <span className="paragraph-sm text-gray-700">
+                    Signed in as <span className="font-semibold">{session.user.name}</span>
+                  </span>
+                  <Button className="w-full" onClick={handleLogout} theme="dark">
+                    Logout <ArrowRightIcon className="h-3 w-3" />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex w-full flex-col">
+                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
+                    <Button className="w-full rounded-none" theme="primary">
+                      Log In
+                    </Button>
+                  </Link>
+                  <Link
+                    className="grid grid-cols-4"
+                    href={Routes.SIGN_UP}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    <Button className="col-span-4 rounded-b-none" theme="dark">
+                      Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
+                    </Button>
+                    <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+                    <div className="h-0.5 w-full bg-blue-400" />
+                    <div className="h-0.5 w-full bg-purple-400" />
+                    <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
+                  </Link>
+                </div>
+              ))}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/Composite/Navbar/Navbar.stories.tsx
+++ b/src/components/Composite/Navbar/Navbar.stories.tsx
@@ -6,6 +6,11 @@ import { Navbar } from "./Navbar"
 const meta: Meta<typeof Navbar> = {
   title: "Composite Components/Navbar",
   component: Navbar,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   args: {
     socialLinks: [
       { label: "Discord", icon: SOCIAL_ICONS.Discord, href: "https://discord.gg/xSgqAmGE" },

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -13,6 +13,8 @@ import { Routes } from "@/lib/routes"
 import { MobileNavbar } from "./MobileNavbar/MobileNavbar"
 import { NavbarGradient } from "./NavbarGradient"
 
+type Session = typeof authClient.$Infer.Session
+
 /**
  * Props for the {@link Navbar} component.
  */
@@ -25,6 +27,11 @@ export interface NavbarProps {
    * Social links to be displayed in the dropdown on the right of the navbar's middle.
    */
   socialLinks: SocialLink[]
+  /**
+   * Session fetched on the server, used as the initial value before the
+   * client session hook resolves. Prevents a flash/skeleton on first paint.
+   */
+  initialSession?: Session | null
 }
 
 /**
@@ -34,8 +41,9 @@ export interface NavbarProps {
  * @param socialLinks Social links to be displayed in the dropdown on the right of the navbar's middle.
  * @returns A Navbar component with logo, navigation links, social dropdown, and join button.
  */
-export function Navbar({ links, socialLinks }: NavbarProps) {
-  const { data: session, isPending } = authClient.useSession()
+export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
+  const { data: hookSession, isPending } = authClient.useSession()
+  const session = isPending ? initialSession : hookSession
   const router = useRouter()
 
   const handleLogout = async () => {
@@ -63,7 +71,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
             <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
           </Link>
         </motion.div>
-        <MobileNavbar links={links} socialLinks={socialLinks} />
+        <MobileNavbar initialSession={initialSession} links={links} socialLinks={socialLinks} />
         <div className="nowrap hidden flex-row md:flex lg:gap-5">
           <div className="flex flex-row items-center gap-5">
             {links
@@ -81,29 +89,25 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          {!isPending &&
-            (session ? (
-              <Dropdown
-                label={session.user.name.split(" ")[0].toUpperCase()}
-                options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
-                theme="dark"
-                triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
-              />
-            ) : (
-              <div className="flex flex-row items-center gap-3">
-                <Link href={Routes.LOGIN}>
-                  <Button theme="primary">Log In</Button>
-                </Link>
-                <Link href={Routes.SIGN_UP}>
-                  <Button
-                    right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />}
-                    theme="dark"
-                  >
-                    Join UOACS
-                  </Button>
-                </Link>
-              </div>
-            ))}
+          {session ? (
+            <Dropdown
+              label={session.user.name.split(" ")[0].toUpperCase()}
+              options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
+              theme="dark"
+              triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
+            />
+          ) : (
+            <div className="flex flex-row items-center gap-3">
+              <Link href={Routes.LOGIN}>
+                <Button theme="primary">Log In</Button>
+              </Link>
+              <Link href={Routes.SIGN_UP}>
+                <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
+                  Join UOACS
+                </Button>
+              </Link>
+            </div>
+          )}
         </div>
       </nav>
     </>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -87,6 +87,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
                 label={session.user.name.split(" ")[0].toUpperCase()}
                 options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
                 theme="dark"
+                triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
               />
             ) : (
               <div className="flex flex-row items-center gap-3">

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -4,9 +4,11 @@ import { ArrowUpRightIcon, Bars3Icon } from "@heroicons/react/24/solid"
 import { motion } from "motion/react"
 import Image from "next/image"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import type { SocialLink } from "@/components/Generic"
 import { Button, Dropdown } from "@/components/Primitive"
 import { SocialIcon } from "@/components/Primitive/Icons"
+import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { MobileNavbar } from "./MobileNavbar/MobileNavbar"
 import { NavbarGradient } from "./NavbarGradient"
@@ -33,6 +35,15 @@ export interface NavbarProps {
  * @returns A Navbar component with logo, navigation links, social dropdown, and join button.
  */
 export function Navbar({ links, socialLinks }: NavbarProps) {
+  const { data: session, isPending } = authClient.useSession()
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    await authClient.signOut()
+    router.push(Routes.HOME)
+    router.refresh()
+  }
+
   const dropdownOptions = socialLinks.map((socialLink) => ({
     label: (
       <span className="flex items-center gap-2">
@@ -70,11 +81,29 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          <Link href={Routes.SIGN_UP}>
-            <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
-              Join UOACS
-            </Button>
-          </Link>
+          {!isPending &&
+            (session ? (
+              <div className="flex flex-row items-center gap-3">
+                <span className="paragraph-sm text-gray-700">{session.user.name}</span>
+                <Button onClick={handleLogout} theme="dark">
+                  Logout
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-row items-center gap-3">
+                <Link href={Routes.LOGIN}>
+                  <Button theme="primary">Log In</Button>
+                </Link>
+                <Link href={Routes.SIGN_UP}>
+                  <Button
+                    right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />}
+                    theme="dark"
+                  >
+                    Join UOACS
+                  </Button>
+                </Link>
+              </div>
+            ))}
         </div>
       </nav>
     </>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -84,10 +84,12 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
           {!isPending &&
             (session ? (
               <div className="flex flex-row items-center gap-3">
-                <span className="paragraph-sm text-gray-700">{session.user.name}</span>
                 <Button onClick={handleLogout} theme="dark">
                   Logout
                 </Button>
+                <span className="paragraph-sm text-gray-700 uppercase">
+                  {session.user.name.split(" ")[0]}
+                </span>
               </div>
             ) : (
               <div className="flex flex-row items-center gap-3">

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -83,14 +83,11 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
           </div>
           {!isPending &&
             (session ? (
-              <div className="flex flex-row items-center gap-3">
-                <Button onClick={handleLogout} theme="dark">
-                  Logout
-                </Button>
-                <span className="paragraph-sm text-gray-700 uppercase">
-                  {session.user.name.split(" ")[0]}
-                </span>
-              </div>
+              <Dropdown
+                label={session.user.name.split(" ")[0].toUpperCase()}
+                options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
+                theme="dark"
+              />
             ) : (
               <div className="flex flex-row items-center gap-3">
                 <Link href={Routes.LOGIN}>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -97,16 +97,11 @@ export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           ) : (
-            <div className="flex flex-row items-center gap-3">
-              <Link href={Routes.LOGIN}>
-                <Button theme="primary">Log In</Button>
-              </Link>
-              <Link href={Routes.SIGN_UP}>
-                <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
-                  Join UOACS
-                </Button>
-              </Link>
-            </div>
+            <Link href={Routes.LOGIN}>
+              <Button right={<ArrowUpRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
+                Log In
+              </Button>
+            </Link>
           )}
         </div>
       </nav>


### PR DESCRIPTION
# Description

This PR makes the `Navbar` and `MobileNavbar` session-aware using Better Auth, so visitors see a `Log In` link when logged out and a dropdown with their first name + `Logout` option when logged in.

- updates `Navbar.tsx` to call `authClient.useSession()` and `useRouter()` and render session-dependent controls
  - when logged out, renders a `Log In` link to `/login` alongside the existing `Join UOACS` CTA
  - when logged in, replaces those controls with a `Dropdown` whose trigger is `session.user.name.split(\" \")[0].toUpperCase()` and whose single option is `Logout`
  - reuses the `Bars3Icon` trigger icon from the Socials dropdown for visual consistency
  - gates rendering on `!isPending` from `useSession` to avoid flashing the wrong state during hydration
- adds a `handleLogout` handler that calls `authClient.signOut()` then `router.push(Routes.HOME)` and `router.refresh()` to clear the Better Auth session and return the user to the home page
- mirrors the same session logic in `MobileNavbar.tsx`
  - keeps the `Interested? Join UOACS` CTA visible regardless of session state
  - places either the user dropdown (logged in) or the `Log In` link (logged out) below the CTA
  - wraps the drawer auth controls in \`<div className=\"flex flex-col items-center gap-4\">\` for centered, content-width layout
  - closes the drawer via \`setIsOpen(false)\` before signing out
- adds \`parameters.nextjs.appDirectory: true\` to \`Navbar.stories.tsx\` so the story mounts cleanly now that \`Navbar\` uses \`useRouter\`

Closes #255

## Additional context

I think when we extend to having a user profile we should remove the dropdown option for the display name button and have it redirect to a user profile page instead. Currently the mobile nav bar looks a bit awkward with the display name button. When we extend to having user profiles I'm thinking we can add the user profile button to be apart of the home, meet the team and our sponsors section just below it, leaving just the interested join us button as a standalone.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

Manual test steps:

- start the dev server and open the home page while logged out
  - verify the desktop navbar shows a \`Log In\` link (routes to \`/login\`) next to the \`Join UOACS\` CTA
  - open the mobile drawer and verify \`Interested? Join UOACS\` is visible with the \`Log In\` link below it
- sign up or log in via \`/login\`, then return to the home page
  - verify the desktop navbar now shows a dropdown whose trigger is your uppercase first name and whose single option is \`Logout\`
  - open the mobile drawer and verify the same dropdown appears below the \`Interested? Join UOACS\` CTA
- click \`Logout\` from either the desktop dropdown or the mobile drawer
  - verify the Better Auth session is cleared, you are redirected to the home page, and the navbar reverts to the logged-out controls
  - verify the mobile drawer closes automatically when logging out from it
- reload the page while logged in and verify the navbar does not flash the logged-out state before settling (guarded by \`isPending\`)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member