### PR TITLE
fix(google-wallet): decode base64-encoded service account env var on use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+service-account.json
 
 # vercel
 .vercel

--- a/src/lib/wallet-integration.ts
+++ b/src/lib/wallet-integration.ts
@@ -25,8 +25,9 @@ if (!process.env.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY) {
 if (!process.env.GOOGLE_WALLET_ISSUER_ID) {
   throw new Error("GOOGLE_WALLET_ISSUER_ID environment variable not set")
 }
-
-const data = JSON.parse(process.env.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY)
+const data = JSON.parse(
+  Buffer.from(process.env.GOOGLE_WALLET_SERVICE_ACCOUNT_KEY, "base64").toString(),
+)
 
 export const credentials = {
   // service account credientails for Oauth and key signing


### PR DESCRIPTION
# Description

This PR fixes the `GOOGLE_WALLET_SERVICE_ACCOUNT_KEY` environment variable handling by decoding it from base64 at the point of use, and ignores the local `service-account.json` file to prevent accidental commits.
This ensures that we don't have to deal with any quote escaping logic that differs when working with the variable in different places/environments.

- decodes `GOOGLE_WALLET_SERVICE_ACCOUNT_KEY` from base64 using `Buffer.from(..., "base64").toString()` before passing it to `JSON.parse()` in `wallet-integration.ts`
- adds `service-account.json` to `.gitignore` to prevent the raw credentials file from being committed

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member