### PR TITLE
fix(renovate): add issues:write permission to fix Dependency Dashboard

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

This PR fixes `integration-unauthorized` errors that occur when Renovate attempts to create or update its Dependency Dashboard issue by adding the missing `issues: write` permission to the Renovate workflow.

- adds `issues: write` to the `permissions` block in `.github/workflows/renovate.yaml`

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Note that this can be verified by triggering the Renovate workflow manually via `workflow_dispatch` and confirming no `integration-unauthorized` errors appear in the run logs.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member