### PR TITLE
fix(renovate): save fresh cache after reset instead of discarding it

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -62,14 +62,14 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
 
       - name: Compress renovate cache
-        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        if: ${{ github.event.inputs.repoCache != 'disabled' }}
         run: |
           ls $cache_dir
           tar -czvf $cache_archive -C $cache_dir .
 
       - name: Upload renovate cache
         uses: actions/upload-artifact@v4
-        if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
+        if: ${{ github.event.inputs.repoCache != 'disabled' }}
         with:
           name: ${{ env.cache_key }}
           path: ${{ env.cache_archive }}


### PR DESCRIPTION
# Description

This PR fixes the `renovate.yaml` workflow so that a fresh cache generated during a `reset` run is saved, rather than silently discarded.

Previously, both the "Compress renovate cache" and "Upload renovate cache" steps had `if` conditions that skipped them when `repoCache` was either `disabled` or `reset`. The `reset` exclusion was wrong — on a reset run, Renovate starts with no restored cache but still generates a new one. Skipping the upload meant every reset run threw away the fresh cache, so the next regular run would find nothing to restore.

- removes `&& github.event.inputs.repoCache != 'reset'` from the `if` condition on the "Compress renovate cache" step
- removes the same condition from the "Upload renovate cache" step
- leaves the `disabled` exclusion intact, so cache persistence is still fully skipped when explicitly disabled

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Trigger the Renovate workflow with `repoCache` set to `reset` and confirm the cache artifact is uploaded at the end of the run. Then trigger again with `reset` to verify the artifact from the previous run is restored before Renovate starts fresh.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member