### PR TITLE
feat(profile): add profile page with member details editing

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -95,7 +95,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
     >
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
         <Toaster />
-        <div className="mx-auto flex w-full max-w-[1480px] grow flex-col gap-14 px-4 py-6 md:gap-9 md:px-12 lg:px-20">
+        <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
           <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
           <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
         </div>

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/solid"
-import type { User } from "better-auth"
 import { useState } from "react"
 import { ToggleableInput } from "@/components/Generic"
 import { Button, Heading, Input, MultiSelect, Radio, Select } from "@/components/Primitive"
@@ -22,7 +21,11 @@ const OTHER_MAJORS_OPTIONS = [
   "Mathematics",
 ]
 
-export const ProfilePageClient = ({ member, user }: { member: Member; user: User }) => {
+export type ProfilePageClientProps = {
+  member: Member
+}
+
+export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
   const [firstName, setFirstName] = useState(member.firstName ?? "")
   const [lastName, setLastName] = useState(member.lastName ?? "")
   const [email, setEmail] = useState(member.email ?? "")

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/solid"
+import type { User } from "better-auth"
+import { useState } from "react"
+import { ToggleableInput } from "@/components/Generic"
+import { Button, Heading, Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import type { Member } from "@/payload/payload-types"
+
+const STUDY_YEAR_OPTIONS = [
+  { label: "First Year", value: "first-year" },
+  { label: "Second Year", value: "second-year" },
+  { label: "Third Year", value: "third-year" },
+
+  { label: "Fifth Year or Above", value: "fifth-year-or-above" },
+]
+
+const OTHER_MAJORS_OPTIONS = [
+  "Information and Technology Management",
+  "Software Engineering",
+  "Information Systems",
+  "Mathematics",
+]
+
+export const ProfilePageClient = ({ member, user }: { member: Member; user: User }) => {
+  const [firstName, setFirstName] = useState(member.firstName ?? "")
+  const [lastName, setLastName] = useState(member.lastName ?? "")
+  const [email, setEmail] = useState(member.email ?? "")
+  const [upi, setUpi] = useState(member.upi ?? "")
+  const [uoaID, setUoaID] = useState(member.uoaID ?? "")
+  const [phoneNumber, setPhoneNumber] = useState(member.phoneNumber ?? "")
+  const [gender, setGender] = useState(member.gender ?? "")
+  const [studyYear, setStudyYear] = useState<string>(member.studyYear ?? "")
+  const [compsciStudent, setCompsciStudent] = useState(
+    member.compsciStudent === true ? "Yes" : member.compsciStudent === false ? "No" : undefined,
+  )
+  const [otherMajors, setOtherMajors] = useState<string[]>(member.otherMajors ?? [])
+  const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
+  const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
+
+  const handleSave = () => {
+    // TODO: persist field update
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-12">
+      <section className="flex w-full flex-col items-start gap-2">
+        <p className="font-mono font-paragraph">
+          {/** biome-ignore lint/suspicious/noCommentText: the // is not for a comment */}
+          <span className="text-primary">// </span>YOUR ACCOUNT
+        </p>
+        <Heading h={2} period>
+          {`${member.firstName} ${member.lastName}`}
+        </Heading>
+        <p className="flex flex-row justify-start gap-2 font-mono text-paragraph-sm">
+          <span>
+            UPI <span className="font-bold text-black">{member.upi ?? "N/A"}</span>
+          </span>
+          <span> / </span>
+          <span>
+            ID <span className="font-bold text-black">{member.uoaID ?? "N/A"}</span>
+          </span>
+        </p>
+      </section>
+      <section className="flex w-full flex-col items-start gap-6">
+        <div className="flex flex-col items-start gap-2">
+          <p className="font-mono font-paragraph">
+            {/** biome-ignore lint/suspicious/noCommentText: the // is not for a comment */}
+            <span className="text-primary">// </span>MEMBER DETAILS
+          </p>
+          <Heading h={3}>Your Info</Heading>
+        </div>
+        <div className="flex w-full flex-col items-start gap-4">
+          <ToggleableInput displayNode={firstName} label="First Name" onSave={handleSave}>
+            <Input onChange={(e) => setFirstName(e.target.value)} type="text" value={firstName} />
+          </ToggleableInput>
+
+          <ToggleableInput displayNode={lastName} label="Last Name" onSave={handleSave}>
+            <Input onChange={(e) => setLastName(e.target.value)} type="text" value={lastName} />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={email}
+            label="Email"
+            locked
+            lockedReason="Email is used for login and cannot be changed here"
+          >
+            <Input onChange={(e) => setEmail(e.target.value)} type="email" value={email} />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={upi}
+            label="UPI"
+            locked
+            lockedReason="UPI is your university identifier and cannot be changed here"
+          >
+            <Input onChange={(e) => setUpi(e.target.value)} type="text" value={upi} />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={uoaID}
+            label="UOA ID Number"
+            locked
+            lockedReason="Your student ID cannot be changed here"
+          >
+            <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
+          </ToggleableInput>
+
+          <ToggleableInput displayNode={gender} label="Gender" onSave={handleSave}>
+            <Select
+              onChange={setGender}
+              options={["Male", "Female", "Other", "Prefer not to say"]}
+              value={gender}
+            />
+          </ToggleableInput>
+
+          <ToggleableInput displayNode={phoneNumber} label="Phone Number" onSave={handleSave}>
+            <Input
+              onChange={(e) => setPhoneNumber(e.target.value)}
+              type="text"
+              value={phoneNumber}
+            />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={compsciStudent ?? ""}
+            label="Are you a computer science student?"
+            onSave={handleSave}
+          >
+            <Radio
+              onChange={setCompsciStudent}
+              options={["Yes", "No"]}
+              optionsClassName="flex-row"
+              value={compsciStudent}
+            />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={STUDY_YEAR_OPTIONS.find((o) => o.value === studyYear)?.label ?? studyYear}
+            label="Year of Study"
+            onSave={handleSave}
+          >
+            <Select onChange={setStudyYear} options={STUDY_YEAR_OPTIONS} value={studyYear} />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={otherMajors.join(", ")}
+            label={compsciStudent === "Yes" ? "Other Majors (if any)" : "Other Majors"}
+            onSave={handleSave}
+          >
+            <MultiSelect
+              customTextInput
+              onChange={setOtherMajors}
+              options={OTHER_MAJORS_OPTIONS}
+              value={otherMajors}
+            />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={heardAboutUs}
+            label="How did you hear about us?"
+            onSave={handleSave}
+          >
+            <Input
+              onChange={(e) => setHeardAboutUs(e.target.value)}
+              type="text"
+              value={heardAboutUs}
+            />
+          </ToggleableInput>
+
+          <ToggleableInput
+            displayNode={eventWishlist}
+            label="What kinds of events would you like to see us host?"
+            onSave={handleSave}
+          >
+            <Input
+              onChange={(e) => setEventWishlist(e.target.value)}
+              type="text"
+              value={eventWishlist}
+            />
+          </ToggleableInput>
+        </div>
+      </section>
+      <section>
+        <div className="flex flex-row justify-between">
+          <p className="font-mono">
+            Signed in as{" "}
+            <span className="font-bold">{`${member.firstName} ${member.lastName}`}</span>
+          </p>
+          <Button
+            left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
+            onClick={() => {}}
+            theme="dark"
+          >
+            Sign Out
+          </Button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -1,9 +1,12 @@
 "use client"
 
 import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/solid"
+import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { ToggleableInput } from "@/components/Generic"
 import { Button, Heading, Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import { authClient } from "@/lib/auth-client"
+import { Routes } from "@/lib/routes"
 import type { Member } from "@/payload/payload-types"
 
 const STUDY_YEAR_OPTIONS = [
@@ -40,6 +43,8 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
   const [otherMajors, setOtherMajors] = useState<string[]>(member.otherMajors ?? [])
   const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
   const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
+
+  const router = useRouter()
 
   const handleSave = () => {
     // TODO: persist field update
@@ -193,7 +198,10 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
           <Button
             className="whitespace-nowrap"
             left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
-            onClick={() => {}}
+            onClick={() => {
+              authClient.signOut()
+              router.push(Routes.LOGIN)
+            }}
             theme="dark"
           >
             Sign Out

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -191,6 +191,7 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
             <span className="font-bold">{`${member.firstName} ${member.lastName}`}</span>
           </p>
           <Button
+            className="whitespace-nowrap"
             left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
             onClick={() => {}}
             theme="dark"

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -1,0 +1,24 @@
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { auth } from "@/lib/auth"
+import { Routes } from "@/lib/routes"
+import { AuthService } from "@/services/auth.service"
+import { ProfilePageClient } from "./_components/ProfilePageClient"
+
+const authService = new AuthService()
+
+export default async function ProfilePage() {
+  const session = await auth.api.getSession({ headers: await headers() })
+
+  if (!session) {
+    redirect(Routes.LOGIN)
+  }
+
+  const member = await authService.getMemberFromUser(session.user)
+
+  if (!member) {
+    redirect(Routes.LOGIN)
+  }
+
+  return <ProfilePageClient member={member} user={session.user} />
+}

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -20,5 +20,5 @@ export default async function ProfilePage() {
     redirect(Routes.LOGIN)
   }
 
-  return <ProfilePageClient member={member} user={session.user} />
+  return <ProfilePageClient member={member} />
 }

--- a/src/components/Composite/HeroSection/HeroSection.tsx
+++ b/src/components/Composite/HeroSection/HeroSection.tsx
@@ -14,7 +14,7 @@ export const HeroSection = ({
   const START_YEAR = 2024
 
   return (
-    <section className="flex w-full max-w-180 flex-col items-center justify-start gap-6 self-center md:items-start md:gap-18 md:self-start">
+    <section className="flex w-full max-w-180 flex-col items-center justify-start gap-6 self-center py-14 md:items-start md:gap-18 md:self-start md:py-0">
       <p className="hidden font-mono md:block">
         UNIVERSITY OF AUCKLAND
         <br />

--- a/src/components/Generic/ToggleableInput/ToggleableInput.tsx
+++ b/src/components/Generic/ToggleableInput/ToggleableInput.tsx
@@ -59,7 +59,7 @@ export const ToggleableInput = ({
           {locked ? null : (
             <>
               {!isEditable && (
-                <div className="opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+                <div className="opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100 [@media(hover:none)]:opacity-100">
                   <Button
                     aria-label={`Edit ${label}`}
                     className="h-auto px-2 py-1 text-xs leading-none md:h-auto"

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,6 +3,7 @@ export const Routes = {
   TEAM: "/team",
   SPONSORS: "/sponsors",
   PRIVACY: "/privacy",
+  PROFILE: "/profile",
   SIGN_UP: "/sign-up",
   LOGIN: "/login",
   GOOGLE_WALLET: "/google-wallet",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,7 +1,0 @@
-import { z } from "zod"
-import { memberSchema } from "./schemas/member"
-import { userSchema } from "./schemas/user"
-
-export const memberWithAuthSchema = z.union([memberSchema, userSchema])
-
-export type MemberWithAuth = z.infer<typeof memberWithAuthSchema>

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+import { memberSchema } from "./schemas/member"
+import { userSchema } from "./schemas/user"
+
+export const memberWithAuthSchema = z.union([memberSchema, userSchema])
+
+export type MemberWithAuth = z.infer<typeof memberWithAuthSchema>


### PR DESCRIPTION
# Description

This PR adds the profile page feature that allows authenticated users to view and edit their member account details. The page leverages the new `ToggleableInput` component to provide inline field editing.

Key additions:
- adds new profile page route at `/profile` with server-side session verification
- creates `ProfilePageClient` component displaying member information fields with inline editing
- implements locked fields for sensitive data (email, UPI, UOA ID) that cannot be edited
- integrates with the `ToggleableInput` component for gender, study year, and major selection fields
  - adds the ability to persist the edit button on devices lacking hover abilities

Closes #287 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<img width="1913" height="1242" alt="Screenshot 2026-06-02 at 00 29 30" src="https://github.com/user-attachments/assets/a0824857-0bc0-43b9-a0c5-14bc3bd42e90" />
<img width="381" height="905" alt="Screenshot 2026-06-02 at 00 29 58" src="https://github.com/user-attachments/assets/9f2540d5-3b6a-40a5-9261-b6623892d2b5" />

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
