### PR TITLE
chore: improve renovate workflow cache handling

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download renovate cache
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         if: ${{ github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset' }}
         continue-on-error: true
         with:
@@ -64,7 +64,10 @@ jobs:
       - name: Compress renovate cache
         if: ${{ github.event.inputs.repoCache != 'disabled' }}
         run: |
-          ls $cache_dir
+          if [ ! -d "$cache_dir" ]; then
+            echo "Cache dir not found — Renovate likely aborted early. Skipping."
+            exit 0
+          fi
           tar -czvf $cache_archive -C $cache_dir .
 
       - name: Upload renovate cache
@@ -73,4 +76,4 @@ jobs:
         with:
           name: ${{ env.cache_key }}
           path: ${{ env.cache_archive }}
-          retention-days: 1
+          retention-days: 7


### PR DESCRIPTION
## Description

This PR improves the renovate workflow by updating dependencies and making the cache handling more robust.

- updates `dawidd6/action-download-artifact` from v2 to v3 for better compatibility with newer GitHub Actions
- adds a safety check before compressing the cache to gracefully skip when the cache directory is missing (which occurs when Renovate aborts early)
- extends the cache retention period from 1 day to 7 days to reduce redundant workflow runs

These changes reduce noise from failed cache compression steps and improve the overall reliability of the dependency update workflow.

Not related to a ticket.

## How to test this change

To verify these changes:

1. Manually trigger the workflow with "Renovate" action dispatch in the repository's Actions tab
2. Confirm the workflow completes without errors in the "Compress renovate cache" step
3. Check that the cache is successfully uploaded to the artifacts section with a 7-day retention
4. Verify the artifact is downloadable in a subsequent workflow run when cache is enabled