### PR TITLE
feat(auth): add AuthContext to deduplicate client-side session management

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,13 +1,13 @@
 import localFont from "next/font/local"
 import { headers } from "next/headers"
 import type React from "react"
-import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
 import { auth } from "@/lib/auth"
 import { getSocialLinks } from "@/lib/helpers"
 import { ApiRoutes, Routes } from "@/lib/routes"
+import { Providers } from "./providers"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -93,12 +93,15 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       lang="en"
     >
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
-        <Toaster />
-        <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-          <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
-          <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
-        </div>
-        <Footer links={navbarLinks} socialLinks={socialLinks} />
+        <Providers>
+          <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
+            <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
+            <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">
+              {children}
+            </main>
+          </div>
+          <Footer links={navbarLinks} socialLinks={socialLinks} />
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,10 +1,8 @@
 import localFont from "next/font/local"
-import { headers } from "next/headers"
 import type React from "react"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
-import { auth } from "@/lib/auth"
 import { getSocialLinks } from "@/lib/helpers"
 import { ApiRoutes, Routes } from "@/lib/routes"
 import { Providers } from "./providers"
@@ -79,13 +77,8 @@ const navbarLinks: { label: string; href: string }[] = [
   { label: "Our Sponsors", href: Routes.SPONSORS },
 ]
 
-export default async function RootLayout(props: { children: React.ReactNode }) {
-  const { children } = props
-
-  const [socialLinks, session] = await Promise.all([
-    getSocialLinks(),
-    auth.api.getSession({ headers: await headers() }),
-  ])
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const socialLinks = await getSocialLinks()
 
   return (
     <html
@@ -95,7 +88,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
         <Providers>
           <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-            <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
+            <Navbar links={navbarLinks} socialLinks={socialLinks} />
             <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">
               {children}
             </main>

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -198,8 +198,8 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
           <Button
             className="whitespace-nowrap"
             left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
-            onClick={() => {
-              authClient.signOut()
+            onClick={async () => {
+              await authClient.signOut()
               router.push(Routes.LOGIN)
             }}
             theme="dark"

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -7,16 +7,18 @@ import { Routes } from "@/lib/routes"
 import { ProfilePageClient } from "./_components/ProfilePageClient"
 
 export default function ProfilePage() {
-  const { user, member, isLoading } = useAuth()
+  const { user, member, isLoading, memberError } = useAuth()
   const router = useRouter()
 
   useEffect(() => {
-    if (!isLoading && (!user || !member)) {
+    if (!isLoading && !memberError && (!user || !member)) {
       router.replace(Routes.LOGIN)
     }
-  }, [isLoading, user, member, router])
+  }, [isLoading, user, member, memberError, router])
 
   if (isLoading) return <p>Loading...</p>
+
+  if (memberError) return <p>Something went wrong loading your profile. Please try again.</p>
 
   if (!user || !member) return null
 

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -1,18 +1,24 @@
 "use client"
 
-import { redirect } from "next/navigation"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 import { useAuth } from "@/context/AuthContext"
 import { Routes } from "@/lib/routes"
 import { ProfilePageClient } from "./_components/ProfilePageClient"
 
 export default function ProfilePage() {
   const { user, member, isLoading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoading && (!user || !member)) {
+      router.replace(Routes.LOGIN)
+    }
+  }, [isLoading, user, member, router])
 
   if (isLoading) return <p>Loading...</p>
 
-  if (!user || !member) {
-    redirect(Routes.LOGIN)
-  }
+  if (!user || !member) return null
 
   return <ProfilePageClient member={member} />
 }

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -1,22 +1,16 @@
-import { headers } from "next/headers"
+"use client"
+
 import { redirect } from "next/navigation"
-import { auth } from "@/lib/auth"
+import { useAuth } from "@/context/AuthContext"
 import { Routes } from "@/lib/routes"
-import { AuthService } from "@/services/auth.service"
 import { ProfilePageClient } from "./_components/ProfilePageClient"
 
-const authService = new AuthService()
+export default function ProfilePage() {
+  const { user, member, isLoading } = useAuth()
 
-export default async function ProfilePage() {
-  const session = await auth.api.getSession({ headers: await headers() })
+  if (isLoading) return <p>Loading...</p>
 
-  if (!session) {
-    redirect(Routes.LOGIN)
-  }
-
-  const member = await authService.getMemberFromUser(session.user)
-
-  if (!member) {
+  if (!user || !member) {
     redirect(Routes.LOGIN)
   }
 

--- a/src/app/(frontend)/providers.tsx
+++ b/src/app/(frontend)/providers.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { Toaster } from "sonner"
+import { AuthProvider } from "@/context/AuthContext"
+
+interface ProvidersProps {
+  children: ReactNode
+}
+
+export function Providers({ children }: ProvidersProps) {
+  return (
+    <AuthProvider>
+      {children}
+      <Toaster />
+    </AuthProvider>
+  )
+}

--- a/src/app/api/member/me/route.ts
+++ b/src/app/api/member/me/route.ts
@@ -1,0 +1,20 @@
+import { headers } from "next/headers"
+import { NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { AuthService } from "@/services/auth.service"
+
+const authService = new AuthService()
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
+  }
+
+  const member = await authService.getMemberFromUser(session.user)
+  if (!member) {
+    return new Response(JSON.stringify({ error: "Member not found" }), { status: 404 })
+  }
+
+  return NextResponse.json(member)
+}

--- a/src/app/api/member/me/route.ts
+++ b/src/app/api/member/me/route.ts
@@ -11,7 +11,17 @@ export async function GET() {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
   }
 
-  const member = await authService.getMemberFromUser(session.user)
+  let member: Awaited<ReturnType<typeof authService.getMemberFromUser>>
+  try {
+    member = await authService.getMemberFromUser(session.user)
+  } catch (err) {
+    console.error("[GET /api/member/me] Failed to fetch member from Payload", {
+      userId: session.user.id,
+      error: err,
+    })
+    return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 })
+  }
+
   if (!member) {
     return new Response(JSON.stringify({ error: "Member not found" }), { status: 404 })
   }

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -22,7 +22,7 @@ import { mobileNavbarVariants } from "./variants"
  * @param socialLinks Social links to be displayed in the mobile navbar.
  */
 export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
-  const { user, member: _, isLoading: isAuthLoading } = useAuth()
+  const { user, isLoading: isAuthLoading } = useAuth()
   const [isOpen, setIsOpen] = useState(false)
   const router = useRouter()
 

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -8,6 +8,7 @@ import Link, { type LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
+import { useAuth } from "@/context/AuthContext"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
@@ -20,10 +21,9 @@ import { mobileNavbarVariants } from "./variants"
  * @param links Links to be displayed in the mobile navbar.
  * @param socialLinks Social links to be displayed in the mobile navbar.
  */
-export const MobileNavbar = ({ links, socialLinks, initialSession }: NavbarProps) => {
+export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
+  const { user, member: _, isLoading: isAuthLoading } = useAuth()
   const [isOpen, setIsOpen] = useState(false)
-  const { data: hookSession, isPending } = authClient.useSession()
-  const session = isPending ? initialSession : hookSession
   const router = useRouter()
 
   const handleLogout = async () => {
@@ -114,9 +114,13 @@ export const MobileNavbar = ({ links, socialLinks, initialSession }: NavbarProps
               ))}
             </div>
             <div className="flex flex-col items-center gap-4">
-              {session ? (
+              {isAuthLoading ? (
+                <Button disabled theme="dark">
+                  <span className="w-12 animate-pulse rounded bg-white/20">&nbsp;</span>
+                </Button>
+              ) : user ? (
                 <div className="flex flex-row items-center gap-2">
-                  <Button theme="dark">{session.user.name.split(" ")[0].toUpperCase()}</Button>
+                  <Button theme="dark">{user.name.split(" ")[0].toUpperCase()}</Button>
                   <Button onClick={handleLogout} theme="dark">
                     Logout
                   </Button>

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -36,7 +36,7 @@ export interface NavbarProps {
  * @returns A Navbar component with logo, navigation links, social dropdown, and join button.
  */
 export function Navbar({ links, socialLinks }: NavbarProps) {
-  const { user, member: _, isLoading: isAuthLoading } = useAuth()
+  const { user, isLoading: isAuthLoading } = useAuth()
 
   const router = useRouter()
 

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -8,12 +8,11 @@ import { useRouter } from "next/navigation"
 import type { SocialLink } from "@/components/Generic"
 import { Button, Dropdown } from "@/components/Primitive"
 import { SocialIcon } from "@/components/Primitive/Icons"
+import { useAuth } from "@/context/AuthContext"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { MobileNavbar } from "./MobileNavbar/MobileNavbar"
 import { NavbarGradient } from "./NavbarGradient"
-
-type Session = typeof authClient.$Infer.Session
 
 /**
  * Props for the {@link Navbar} component.
@@ -27,11 +26,6 @@ export interface NavbarProps {
    * Social links to be displayed in the dropdown on the right of the navbar's middle.
    */
   socialLinks: SocialLink[]
-  /**
-   * Session fetched on the server, used as the initial value before the
-   * client session hook resolves. Prevents a flash/skeleton on first paint.
-   */
-  initialSession?: Session | null
 }
 
 /**
@@ -41,9 +35,9 @@ export interface NavbarProps {
  * @param socialLinks Social links to be displayed in the dropdown on the right of the navbar's middle.
  * @returns A Navbar component with logo, navigation links, social dropdown, and join button.
  */
-export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
-  const { data: hookSession, isPending } = authClient.useSession()
-  const session = isPending ? initialSession : hookSession
+export function Navbar({ links, socialLinks }: NavbarProps) {
+  const { user, member: _, isLoading: isAuthLoading } = useAuth()
+
   const router = useRouter()
 
   const handleLogout = async () => {
@@ -71,7 +65,7 @@ export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
             <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
           </Link>
         </motion.div>
-        <MobileNavbar initialSession={initialSession} links={links} socialLinks={socialLinks} />
+        <MobileNavbar links={links} socialLinks={socialLinks} />
         <div className="nowrap hidden flex-row md:flex lg:gap-5">
           <div className="flex flex-row items-center gap-5">
             {links
@@ -89,9 +83,13 @@ export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
             />
           </div>
-          {session ? (
+          {isAuthLoading ? (
+            <Button disabled theme="dark">
+              <span className="w-12 animate-pulse rounded bg-white/20">&nbsp;</span>
+            </Button>
+          ) : user ? (
             <Dropdown
-              label={session.user.name.split(" ")[0].toUpperCase()}
+              label={user.name.split(" ")[0].toUpperCase()}
               options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
               theme="dark"
               triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ const AuthContext = createContext<AuthState | undefined>(undefined)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [member, setMember] = useState<Member | null>(null)
   const [memberLoading, setMemberLoading] = useState(true)
+  const [memberError, setMemberError] = useState<Error | null>(null)
 
   const { data: session, isPending } = authClient.useSession()
   const userId = session?.user?.id
@@ -19,19 +20,44 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (isPending) return
     if (!userId) {
       setMember(null)
+      setMemberError(null)
       setMemberLoading(false)
       return
     }
+    let cancelled = false
     setMemberLoading(true)
+    setMemberError(null)
     fetch(ApiRoutes.MEMBER.ME)
-      .then((r) => (r.ok ? r.json() : null))
-      .then(setMember)
-      .finally(() => setMemberLoading(false))
+      .then((r) => {
+        if (r.ok) return r.json()
+        if (r.status === 404) return null
+        throw new Error(`Unexpected response: ${r.status}`)
+      })
+      .then((data) => {
+        if (!cancelled) setMember(data)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AuthContext] Failed to fetch member", { userId, error: err })
+          setMemberError(err instanceof Error ? err : new Error(String(err)))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setMemberLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [userId, isPending])
 
   return (
     <AuthContext.Provider
-      value={{ user: session?.user ?? null, member, isLoading: isPending || memberLoading }}
+      value={{
+        user: session?.user ?? null,
+        member,
+        isLoading: isPending || memberLoading,
+        memberError,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, type ReactNode, useContext, useEffect, useState } from "react"
 import { authClient } from "@/lib/auth-client"
+import { ApiRoutes } from "@/lib/routes"
 import type { Member } from "@/payload/payload-types"
 import type { AuthState } from "@/types/auth"
 
@@ -22,7 +23,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return
     }
     setMemberLoading(true)
-    fetch("/api/member/me")
+    fetch(ApiRoutes.MEMBER.ME)
       .then((r) => (r.ok ? r.json() : null))
       .then(setMember)
       .finally(() => setMemberLoading(false))

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { createContext, type ReactNode, useContext, useEffect, useState } from "react"
+import { authClient } from "@/lib/auth-client"
+import type { Member } from "@/payload/payload-types"
+import type { AuthState } from "@/types/auth"
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [member, setMember] = useState<Member | null>(null)
+  const [memberLoading, setMemberLoading] = useState(false)
+
+  const { data: session, isPending } = authClient.useSession()
+
+  useEffect(() => {
+    if (!session?.user) {
+      setMember(null)
+      return
+    }
+    setMemberLoading(true)
+    fetch("/api/member/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then(setMember)
+      .finally(() => setMemberLoading(false))
+  }, [session?.user])
+
+  return (
+    <AuthContext.Provider
+      value={{ user: session?.user ?? null, member, isLoading: isPending || memberLoading }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider")
+  }
+  return context
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -9,13 +9,16 @@ const AuthContext = createContext<AuthState | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [member, setMember] = useState<Member | null>(null)
-  const [memberLoading, setMemberLoading] = useState(false)
+  const [memberLoading, setMemberLoading] = useState(true)
 
   const { data: session, isPending } = authClient.useSession()
+  const userId = session?.user?.id
 
   useEffect(() => {
-    if (!session?.user) {
+    if (isPending) return
+    if (!userId) {
       setMember(null)
+      setMemberLoading(false)
       return
     }
     setMemberLoading(true)
@@ -23,7 +26,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .then((r) => (r.ok ? r.json() : null))
       .then(setMember)
       .finally(() => setMemberLoading(false))
-  }, [session?.user])
+  }, [userId, isPending])
 
   return (
     <AuthContext.Provider

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -24,6 +24,9 @@ export const ApiRoutes = {
     LINK: "/api/google-wallet/link",
     PASS: "/api/google-wallet/pass",
   },
+  MEMBER: {
+    ME: "/api/member/me",
+  },
   OG: "/og",
 } as const
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -5,4 +5,5 @@ export type AuthState = {
   user: User | null
   member: Member | null
   isLoading: boolean
+  memberError: Error | null
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,8 @@
+import type { User } from "better-auth"
+import type { Member } from "@/payload/payload-types"
+
+export type AuthState = {
+  user: User | null
+  member: Member | null
+  isLoading: boolean
+}


### PR DESCRIPTION
# Description

This PR introduces a client-side `AuthContext` that centralises session and member state across the app, replacing the previous approach of fetching session server-side in the layout and passing it down as `initialSession` props.

- adds `AuthContext` and `AuthProvider` to `src/context/AuthContext.tsx` which holds `user`, `member`, `isLoading`, and `memberError` state, fetching member data from `/api/member/me` once the Better Auth session resolves
- adds `AuthState` type to `src/types/auth.ts`
- adds `GET /api/member/me` endpoint that returns the Payload `Member` record for the authenticated user
- adds a `Providers` client component wrapping `AuthProvider` and `Toaster`, replacing the inline `<Toaster />` and server-side session fetch in the root layout
- updates `Navbar` and `MobileNavbar` to consume `useAuth()` instead of the `initialSession` prop — removes the `initialSession` prop from `NavbarProps` entirely
- refactors `ProfilePage` from a server component to a client component using `useAuth()`, handling loading, server error, and unauthenticated states explicitly
- fixes `ProfilePageClient` sign-out handler to `await authClient.signOut()` before pushing the login route

Closes #290

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
