### PR TITLE
feat(auth): improve auth state management with SessionContext and Tanstack Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@payloadcms/richtext-lexical": "3.83.0",
     "@payloadcms/storage-s3": "3.83.0",
     "@payloadcms/ui": "3.83.0",
+    "@tanstack/react-query": "^5.101.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "better-auth": "^1.6.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@payloadcms/ui':
         specifier: 3.83.0
         version: 3.83.0(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(payload@3.83.0(graphql@16.13.2)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.4)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1868,6 +1871,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6542,6 +6553,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.10
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.4
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -93,9 +93,9 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       lang="en"
     >
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
-        <Providers>
+        <Providers initialSession={session}>
           <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-            <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
+            <Navbar links={navbarLinks} socialLinks={socialLinks} />
             <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">
               {children}
             </main>

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,13 +1,12 @@
 import localFont from "next/font/local"
-import { headers } from "next/headers"
 import type React from "react"
-import { Toaster } from "sonner"
 import { Footer, Navbar } from "@/components/Composite"
 import "../globals.css"
 import type { Metadata, Viewport } from "next"
-import { auth } from "@/lib/auth"
+import { getSession } from "@/lib/auth-session"
 import { getDiscordWidgetData, getSocialLinks } from "@/lib/helpers"
 import { ApiRoutes, Routes } from "@/lib/routes"
+import { Providers } from "./providers"
 
 const inter = localFont({
   src: "../../../public/fonts/InterTight-Variable.woff2",
@@ -84,7 +83,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
 
   const [socialLinks, session, discordWidgetData] = await Promise.all([
     getSocialLinks(),
-    auth.api.getSession({ headers: await headers() }),
+    getSession(),
     getDiscordWidgetData(),
   ])
 
@@ -94,16 +93,19 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
       lang="en"
     >
       <body className="relative flex min-h-screen flex-col overflow-x-hidden">
-        <Toaster />
-        <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
-          <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
-          <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">{children}</main>
-        </div>
-        <Footer
-          discordWidgetData={discordWidgetData}
-          links={navbarLinks}
-          socialLinks={socialLinks}
-        />
+        <Providers>
+          <div className="mx-auto flex w-full max-w-[1480px] grow flex-col px-4 py-6 md:gap-9 md:px-12 lg:px-20">
+            <Navbar initialSession={session} links={navbarLinks} socialLinks={socialLinks} />
+            <main className="flex grow flex-col items-center gap-14 py-9 md:gap-30">
+              {children}
+            </main>
+          </div>
+          <Footer
+            discordWidgetData={discordWidgetData}
+            links={navbarLinks}
+            socialLinks={socialLinks}
+          />
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useState } from "react"
+import { ToggleableInput } from "@/components/Generic"
+import { Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import type { Member } from "@/payload/payload-types"
+
+const STUDY_YEAR_OPTIONS = [
+  { label: "First Year", value: "first-year" },
+  { label: "Second Year", value: "second-year" },
+  { label: "Third Year", value: "third-year" },
+  { label: "Fifth Year or Above", value: "fifth-year-or-above" },
+]
+
+const OTHER_MAJORS_OPTIONS = [
+  "Information and Technology Management",
+  "Software Engineering",
+  "Information Systems",
+  "Mathematics",
+]
+
+export const MemberDetailsForm = ({ member }: { member: Member }) => {
+  const [firstName, setFirstName] = useState(member.firstName ?? "")
+  const [lastName, setLastName] = useState(member.lastName ?? "")
+  const [email, setEmail] = useState(member.email ?? "")
+  const [upi, setUpi] = useState(member.upi ?? "")
+  const [uoaID, setUoaID] = useState(member.uoaID ?? "")
+  const [phoneNumber, setPhoneNumber] = useState(member.phoneNumber ?? "")
+  const [gender, setGender] = useState(member.gender ?? "")
+  const [studyYear, setStudyYear] = useState<string>(member.studyYear ?? "")
+  const [compsciStudent, setCompsciStudent] = useState(
+    member.compsciStudent === true ? "Yes" : member.compsciStudent === false ? "No" : undefined,
+  )
+  const [otherMajors, setOtherMajors] = useState<string[]>(member.otherMajors ?? [])
+  const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
+  const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
+
+  const handleSave = () => {
+    // TODO: persist field update
+  }
+
+  return (
+    <div className="flex w-full flex-col items-start gap-4">
+      <ToggleableInput displayNode={firstName} label="First Name" onSave={handleSave}>
+        <Input onChange={(e) => setFirstName(e.target.value)} type="text" value={firstName} />
+      </ToggleableInput>
+
+      <ToggleableInput displayNode={lastName} label="Last Name" onSave={handleSave}>
+        <Input onChange={(e) => setLastName(e.target.value)} type="text" value={lastName} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={email}
+        label="Email"
+        locked
+        lockedReason="Email is used for login and cannot be changed here"
+      >
+        <Input onChange={(e) => setEmail(e.target.value)} type="email" value={email} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={upi}
+        label="UPI"
+        locked
+        lockedReason="UPI is your university identifier and cannot be changed here"
+      >
+        <Input onChange={(e) => setUpi(e.target.value)} type="text" value={upi} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={uoaID}
+        label="UOA ID Number"
+        locked
+        lockedReason="Your student ID cannot be changed here"
+      >
+        <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
+      </ToggleableInput>
+
+      <ToggleableInput displayNode={gender} label="Gender" onSave={handleSave}>
+        <Select
+          onChange={setGender}
+          options={["Male", "Female", "Other", "Prefer not to say"]}
+          value={gender}
+        />
+      </ToggleableInput>
+
+      <ToggleableInput displayNode={phoneNumber} label="Phone Number" onSave={handleSave}>
+        <Input onChange={(e) => setPhoneNumber(e.target.value)} type="text" value={phoneNumber} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={compsciStudent ?? ""}
+        label="Are you a computer science student?"
+        onSave={handleSave}
+      >
+        <Radio
+          onChange={setCompsciStudent}
+          options={["Yes", "No"]}
+          optionsClassName="flex-row"
+          value={compsciStudent}
+        />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={STUDY_YEAR_OPTIONS.find((o) => o.value === studyYear)?.label ?? studyYear}
+        label="Year of Study"
+        onSave={handleSave}
+      >
+        <Select onChange={setStudyYear} options={STUDY_YEAR_OPTIONS} value={studyYear} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={otherMajors.join(", ")}
+        label={compsciStudent === "Yes" ? "Other Majors (if any)" : "Other Majors"}
+        onSave={handleSave}
+      >
+        <MultiSelect
+          customTextInput
+          onChange={setOtherMajors}
+          options={OTHER_MAJORS_OPTIONS}
+          value={otherMajors}
+        />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={heardAboutUs}
+        label="How did you hear about us?"
+        onSave={handleSave}
+      >
+        <Input onChange={(e) => setHeardAboutUs(e.target.value)} type="text" value={heardAboutUs} />
+      </ToggleableInput>
+
+      <ToggleableInput
+        displayNode={eventWishlist}
+        label="What kinds of events would you like to see us host?"
+        onSave={handleSave}
+      >
+        <Input
+          onChange={(e) => setEventWishlist(e.target.value)}
+          type="text"
+          value={eventWishlist}
+        />
+      </ToggleableInput>
+    </div>
+  )
+}

--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -9,6 +9,7 @@ const STUDY_YEAR_OPTIONS = [
   { label: "First Year", value: "first-year" },
   { label: "Second Year", value: "second-year" },
   { label: "Third Year", value: "third-year" },
+  { label: "Fourth Year", value: "fourth-year" },
   { label: "Fifth Year or Above", value: "fifth-year-or-above" },
 ]
 

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -1,54 +1,21 @@
 "use client"
 
 import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/solid"
+import type { User } from "better-auth"
 import { useRouter } from "next/navigation"
-import { useState } from "react"
-import { ToggleableInput } from "@/components/Generic"
-import { Button, Heading, Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import { Button, Heading } from "@/components/Primitive"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
-import type { Member } from "@/payload/payload-types"
-
-const STUDY_YEAR_OPTIONS = [
-  { label: "First Year", value: "first-year" },
-  { label: "Second Year", value: "second-year" },
-  { label: "Third Year", value: "third-year" },
-
-  { label: "Fifth Year or Above", value: "fifth-year-or-above" },
-]
-
-const OTHER_MAJORS_OPTIONS = [
-  "Information and Technology Management",
-  "Software Engineering",
-  "Information Systems",
-  "Mathematics",
-]
+import { useMember } from "@/queries/useMember"
+import { MemberDetailsForm } from "./MemberDetailsForm"
 
 export type ProfilePageClientProps = {
-  member: Member
+  user: User
 }
 
-export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
-  const [firstName, setFirstName] = useState(member.firstName ?? "")
-  const [lastName, setLastName] = useState(member.lastName ?? "")
-  const [email, setEmail] = useState(member.email ?? "")
-  const [upi, setUpi] = useState(member.upi ?? "")
-  const [uoaID, setUoaID] = useState(member.uoaID ?? "")
-  const [phoneNumber, setPhoneNumber] = useState(member.phoneNumber ?? "")
-  const [gender, setGender] = useState(member.gender ?? "")
-  const [studyYear, setStudyYear] = useState<string>(member.studyYear ?? "")
-  const [compsciStudent, setCompsciStudent] = useState(
-    member.compsciStudent === true ? "Yes" : member.compsciStudent === false ? "No" : undefined,
-  )
-  const [otherMajors, setOtherMajors] = useState<string[]>(member.otherMajors ?? [])
-  const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
-  const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
-
+export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
+  const { data: member, isLoading, isError } = useMember(user.id)
   const router = useRouter()
-
-  const handleSave = () => {
-    // TODO: persist field update
-  }
 
   return (
     <div className="flex w-full flex-col gap-12">
@@ -58,18 +25,33 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
           <span className="text-primary">// </span>YOUR ACCOUNT
         </p>
         <Heading h={2} period>
-          {`${member.firstName} ${member.lastName}`}
+          {user.name}
         </Heading>
         <p className="flex flex-row justify-start gap-2 font-mono text-paragraph-sm">
           <span>
-            UPI <span className="font-bold text-black">{member.upi ?? "N/A"}</span>
+            UPI{" "}
+            <span className="font-bold text-black">
+              {isLoading ? (
+                <span className="inline-block h-4 w-12 animate-pulse rounded bg-gray-200 align-middle" />
+              ) : (
+                (member?.upi ?? "N/A")
+              )}
+            </span>
           </span>
           <span> / </span>
           <span>
-            ID <span className="font-bold text-black">{member.uoaID ?? "N/A"}</span>
+            ID{" "}
+            <span className="font-bold text-black">
+              {isLoading ? (
+                <span className="inline-block h-4 w-12 animate-pulse rounded bg-gray-200 align-middle" />
+              ) : (
+                (member?.uoaID ?? "N/A")
+              )}
+            </span>
           </span>
         </p>
       </section>
+
       <section className="flex w-full flex-col items-start gap-6">
         <div className="flex flex-col items-start gap-2">
           <p className="font-mono font-paragraph">
@@ -78,122 +60,19 @@ export const ProfilePageClient = ({ member }: ProfilePageClientProps) => {
           </p>
           <Heading h={3}>Your Info</Heading>
         </div>
-        <div className="flex w-full flex-col items-start gap-4">
-          <ToggleableInput displayNode={firstName} label="First Name" onSave={handleSave}>
-            <Input onChange={(e) => setFirstName(e.target.value)} type="text" value={firstName} />
-          </ToggleableInput>
-
-          <ToggleableInput displayNode={lastName} label="Last Name" onSave={handleSave}>
-            <Input onChange={(e) => setLastName(e.target.value)} type="text" value={lastName} />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={email}
-            label="Email"
-            locked
-            lockedReason="Email is used for login and cannot be changed here"
-          >
-            <Input onChange={(e) => setEmail(e.target.value)} type="email" value={email} />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={upi}
-            label="UPI"
-            locked
-            lockedReason="UPI is your university identifier and cannot be changed here"
-          >
-            <Input onChange={(e) => setUpi(e.target.value)} type="text" value={upi} />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={uoaID}
-            label="UOA ID Number"
-            locked
-            lockedReason="Your student ID cannot be changed here"
-          >
-            <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
-          </ToggleableInput>
-
-          <ToggleableInput displayNode={gender} label="Gender" onSave={handleSave}>
-            <Select
-              onChange={setGender}
-              options={["Male", "Female", "Other", "Prefer not to say"]}
-              value={gender}
-            />
-          </ToggleableInput>
-
-          <ToggleableInput displayNode={phoneNumber} label="Phone Number" onSave={handleSave}>
-            <Input
-              onChange={(e) => setPhoneNumber(e.target.value)}
-              type="text"
-              value={phoneNumber}
-            />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={compsciStudent ?? ""}
-            label="Are you a computer science student?"
-            onSave={handleSave}
-          >
-            <Radio
-              onChange={setCompsciStudent}
-              options={["Yes", "No"]}
-              optionsClassName="flex-row"
-              value={compsciStudent}
-            />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={STUDY_YEAR_OPTIONS.find((o) => o.value === studyYear)?.label ?? studyYear}
-            label="Year of Study"
-            onSave={handleSave}
-          >
-            <Select onChange={setStudyYear} options={STUDY_YEAR_OPTIONS} value={studyYear} />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={otherMajors.join(", ")}
-            label={compsciStudent === "Yes" ? "Other Majors (if any)" : "Other Majors"}
-            onSave={handleSave}
-          >
-            <MultiSelect
-              customTextInput
-              onChange={setOtherMajors}
-              options={OTHER_MAJORS_OPTIONS}
-              value={otherMajors}
-            />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={heardAboutUs}
-            label="How did you hear about us?"
-            onSave={handleSave}
-          >
-            <Input
-              onChange={(e) => setHeardAboutUs(e.target.value)}
-              type="text"
-              value={heardAboutUs}
-            />
-          </ToggleableInput>
-
-          <ToggleableInput
-            displayNode={eventWishlist}
-            label="What kinds of events would you like to see us host?"
-            onSave={handleSave}
-          >
-            <Input
-              onChange={(e) => setEventWishlist(e.target.value)}
-              type="text"
-              value={eventWishlist}
-            />
-          </ToggleableInput>
-        </div>
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : isError ? (
+          <p>Failed to load member details. Please try again.</p>
+        ) : member ? (
+          <MemberDetailsForm member={member} />
+        ) : null}
       </section>
+
       <section>
         <div className="flex flex-row justify-between">
           <p className="font-mono">
-            Signed in as{" "}
-            <span className="font-bold">{`${member.firstName} ${member.lastName}`}</span>
+            Signed in as <span className="font-bold">{user.name}</span>
           </p>
           <Button
             className="whitespace-nowrap"

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -77,8 +77,12 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
           <Button
             className="whitespace-nowrap"
             left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
-            onClick={() => {
-              authClient.signOut()
+            onClick={async () => {
+              try {
+                await authClient.signOut()
+              } catch (err) {
+                console.error("[ProfilePageClient] signOut failed", { error: err })
+              }
               router.push(Routes.LOGIN)
             }}
             theme="dark"

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -1,24 +1,10 @@
-import { headers } from "next/headers"
 import { redirect } from "next/navigation"
-import { auth } from "@/lib/auth"
+import { getSession } from "@/lib/auth-session"
 import { Routes } from "@/lib/routes"
-import { AuthService } from "@/services/auth.service"
 import { ProfilePageClient } from "./_components/ProfilePageClient"
 
-const authService = new AuthService()
-
 export default async function ProfilePage() {
-  const session = await auth.api.getSession({ headers: await headers() })
-
-  if (!session) {
-    redirect(Routes.LOGIN)
-  }
-
-  const member = await authService.getMemberFromUser(session.user)
-
-  if (!member) {
-    redirect(Routes.LOGIN)
-  }
-
-  return <ProfilePageClient member={member} />
+  const session = await getSession()
+  if (!session) redirect(Routes.LOGIN)
+  return <ProfilePageClient user={session.user} />
 }

--- a/src/app/(frontend)/providers.tsx
+++ b/src/app/(frontend)/providers.tsx
@@ -1,12 +1,17 @@
 "use client"
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { ReactNode } from "react"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 import { Toaster } from "sonner"
+import { type Session, SessionProvider } from "@/context/SessionContext"
 
-export function Providers({ children }: { children: ReactNode }) {
-  // Factory initializer prevents a new QueryClient from being created on every render.
+export function Providers({
+  children,
+  initialSession,
+}: {
+  children: ReactNode
+  initialSession?: Session
+}) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -21,9 +26,11 @@ export function Providers({ children }: { children: ReactNode }) {
       }),
   )
   return (
-    <QueryClientProvider client={queryClient}>
-      <Toaster />
-      {children}
-    </QueryClientProvider>
+    <SessionProvider initialSession={initialSession}>
+      <QueryClientProvider client={queryClient}>
+        <Toaster />
+        {children}
+      </QueryClientProvider>
+    </SessionProvider>
   )
 }

--- a/src/app/(frontend)/providers.tsx
+++ b/src/app/(frontend)/providers.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { useState } from "react"
+import { Toaster } from "sonner"
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient())
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Toaster />
+      {children}
+    </QueryClientProvider>
+  )
+}

--- a/src/app/(frontend)/providers.tsx
+++ b/src/app/(frontend)/providers.tsx
@@ -6,7 +6,20 @@ import { useState } from "react"
 import { Toaster } from "sonner"
 
 export function Providers({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient())
+  // Factory initializer prevents a new QueryClient from being created on every render.
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: (failureCount, error) => {
+              if (error instanceof Error && error.message.includes("401")) return false
+              return failureCount < 1
+            },
+          },
+        },
+      }),
+  )
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />

--- a/src/app/api/member/me/route.ts
+++ b/src/app/api/member/me/route.ts
@@ -6,12 +6,12 @@ import { AuthService } from "@/services/auth.service"
 const authService = new AuthService()
 
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
-  }
-
   try {
+    const session = await auth.api.getSession({ headers: await headers() })
+    if (!session) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
+    }
+
     const member = await authService.getMemberFromUser(session.user)
     if (!member) {
       return new Response(JSON.stringify({ error: "Member not found" }), { status: 404 })
@@ -19,7 +19,7 @@ export async function GET() {
 
     return NextResponse.json(member)
   } catch (err) {
-    console.error("[GET /api/member/me]", { userId: session.user.id, error: err })
+    console.error("[GET /api/member/me]", { error: err })
     return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 })
   }
 }

--- a/src/app/api/member/me/route.ts
+++ b/src/app/api/member/me/route.ts
@@ -1,0 +1,25 @@
+import { headers } from "next/headers"
+import { NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { AuthService } from "@/services/auth.service"
+
+const authService = new AuthService()
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 })
+  }
+
+  try {
+    const member = await authService.getMemberFromUser(session.user)
+    if (!member) {
+      return new Response(JSON.stringify({ error: "Member not found" }), { status: 404 })
+    }
+
+    return NextResponse.json(member)
+  } catch (err) {
+    console.error("[GET /api/member/me]", { userId: session.user.id, error: err })
+    return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 })
+  }
+}

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -8,6 +8,7 @@ import Link, { type LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { BorderButton, Button, Heading, SocialIcon } from "@/components/Primitive"
+import { useSession } from "@/context/SessionContext"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { cn } from "@/lib/utils"
@@ -20,10 +21,9 @@ import { mobileNavbarVariants } from "./variants"
  * @param links Links to be displayed in the mobile navbar.
  * @param socialLinks Social links to be displayed in the mobile navbar.
  */
-export const MobileNavbar = ({ links, socialLinks, initialSession }: NavbarProps) => {
+export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false)
-  const { data: hookSession, isPending } = authClient.useSession()
-  const session = isPending ? initialSession : hookSession
+  const session = useSession()
   const router = useRouter()
 
   const handleLogout = async () => {

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -8,12 +8,11 @@ import { useRouter } from "next/navigation"
 import type { SocialLink } from "@/components/Generic"
 import { Button, Dropdown } from "@/components/Primitive"
 import { SocialIcon } from "@/components/Primitive/Icons"
+import { useSession } from "@/context/SessionContext"
 import { authClient } from "@/lib/auth-client"
 import { Routes } from "@/lib/routes"
 import { MobileNavbar } from "./MobileNavbar/MobileNavbar"
 import { NavbarGradient } from "./NavbarGradient"
-
-type Session = typeof authClient.$Infer.Session
 
 /**
  * Props for the {@link Navbar} component.
@@ -27,11 +26,6 @@ export interface NavbarProps {
    * Social links to be displayed in the dropdown on the right of the navbar's middle.
    */
   socialLinks: SocialLink[]
-  /**
-   * Session fetched on the server, used as the initial value before the
-   * client session hook resolves. Prevents a flash/skeleton on first paint.
-   */
-  initialSession?: Session | null
 }
 
 /**
@@ -41,9 +35,8 @@ export interface NavbarProps {
  * @param socialLinks Social links to be displayed in the dropdown on the right of the navbar's middle.
  * @returns A Navbar component with logo, navigation links, social dropdown, and join button.
  */
-export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
-  const { data: hookSession, isPending } = authClient.useSession()
-  const session = isPending ? initialSession : hookSession
+export function Navbar({ links, socialLinks }: NavbarProps) {
+  const session = useSession()
   const router = useRouter()
 
   const handleLogout = async () => {
@@ -71,7 +64,7 @@ export function Navbar({ links, socialLinks, initialSession }: NavbarProps) {
             <Image alt="UOACS Logo" height={40} src="/uoacs-logo-bw.svg" width={167} />
           </Link>
         </motion.div>
-        <MobileNavbar initialSession={initialSession} links={links} socialLinks={socialLinks} />
+        <MobileNavbar links={links} socialLinks={socialLinks} />
         <div className="nowrap hidden flex-row md:flex lg:gap-5">
           <div className="flex flex-row items-center gap-5">
             {links

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, type ReactNode, useContext } from "react"
+import { authClient } from "@/lib/auth-client"
+
+export type Session = typeof authClient.$Infer.Session | null
+
+const SessionContext = createContext<Session | undefined>(undefined)
+
+export function useSession(): Session {
+  const context = useContext(SessionContext)
+  if (context === undefined) throw new Error("useSession must be used within Providers")
+  return context
+}
+
+export const SessionProvider = ({
+  children,
+  initialSession,
+}: {
+  children: ReactNode
+  initialSession?: Session
+}) => {
+  const { data: clientSession, isPending } = authClient.useSession()
+  const session = isPending ? initialSession : (clientSession ?? null)
+
+  return <SessionContext.Provider value={session}>{children}</SessionContext.Provider>
+}

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -2,4 +2,11 @@ import { headers } from "next/headers"
 import { cache } from "react"
 import { auth } from "@/lib/auth"
 
-export const getSession = cache(async () => auth.api.getSession({ headers: await headers() }))
+export const getSession = cache(async () => {
+  try {
+    return await auth.api.getSession({ headers: await headers() })
+  } catch (err) {
+    console.error("[getSession] auth.api.getSession threw unexpectedly", { error: err })
+    return null
+  }
+})

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,0 +1,5 @@
+import { headers } from "next/headers"
+import { cache } from "react"
+import { auth } from "@/lib/auth"
+
+export const getSession = cache(async () => auth.api.getSession({ headers: await headers() }))

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -15,6 +15,9 @@ export const ApiRoutes = {
   ADMIN: {
     MEMBERS: (id: string | number | undefined) => `/api/admin/members/${id ?? ""}`,
   } as const,
+  MEMBER: {
+    ME: "/api/member/me",
+  } as const,
   SIGN_UP: {
     ROOT: "/api/sign-up",
     VERIFICATION_CODE: "/api/sign-up/verification-code",

--- a/src/queries/QueryKeys.ts
+++ b/src/queries/QueryKeys.ts
@@ -1,0 +1,3 @@
+export const QueryKeys = {
+  MEMBER: "member",
+} as const

--- a/src/queries/useMember.ts
+++ b/src/queries/useMember.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
+import { ApiRoutes } from "@/lib/routes"
+import type { Member } from "@/payload/payload-types"
+import { QueryKeys } from "./QueryKeys"
+
+export function useMember(userId: string) {
+  return useQuery<Member>({
+    queryKey: [QueryKeys.MEMBER, userId],
+    queryFn: async () => {
+      const result = await fetch(ApiRoutes.MEMBER.ME)
+      if (!result.ok) throw new Error(`Failed to fetch member: ${result.status}`)
+      return result.json()
+    },
+    enabled: !!userId,
+  })
+}


### PR DESCRIPTION
# Description

This PR improves auth state management by introducing a `SessionContext` and `Providers` component to centralise session state on the client, replacing prop-drilling of `initialSession` through `Navbar` and `MobileNavbar`. It also moves member data fetching to the client via Tanstack Query, allowing the profile page to render with skeleton states rather than blocking on a server-side Payload query.

- adds `SessionContext` and `useSession` hook at `src/context/SessionContext.tsx` as a single source of truth for session state in client components with `initialSession` feeding in so there are no/minimal initial loading state
- adds `Providers` component at `src/app/(frontend)/providers.tsx` wrapping `SessionProvider`, `QueryClientProvider`, and `Toaster`
- adds `getSession` cached helper at `src/lib/auth-session.ts` using React `cache` to deduplicate `auth.api.getSession` calls per request
- removes `initialSession` prop from `Navbar` and `MobileNavbar`, both now read session via `useSession()`
- adds `GET /api/member/me` route at `src/app/api/member/me/route.ts` returning the authenticated user's `Member` document
- adds `useMember` query hook at `src/queries/useMember.ts` and `QueryKeys` constant
- refactors `ProfilePageClient` to accept `user` instead of `member`, fetching member data client-side via `useMember`
  - extracts member field state and form UI into `MemberDetailsForm` component

Closes #290

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
