### PR TITLE
feat(profile): add PATCH /api/profile endpoint with member update logic

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -2,12 +2,13 @@ import { type NextRequest, NextResponse } from "next/server"
 import { ValidationError } from "payload"
 import { ZodError } from "zod"
 import { auth } from "@/lib/auth"
+import type { Member } from "@/payload/payload-types"
 import { AuthService, DuplicateFieldError } from "@/services/auth.service"
 import { updateMemberSchema } from "@/types/schemas/member"
 
 export async function PATCH(req: NextRequest) {
   let session: Awaited<ReturnType<typeof auth.api.getSession>> | undefined
-  let member: Awaited<ReturnType<InstanceType<typeof AuthService>["getMemberFromUser"]>> | undefined
+  let member: Member | null | undefined
 
   try {
     session = await auth.api.getSession({ headers: req.headers })

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { ValidationError } from "payload"
+import { ZodError } from "zod"
+import { auth } from "@/lib/auth"
+import { AuthService, DuplicateFieldError } from "@/services/auth.service"
+import { updateMemberSchema } from "@/types/schemas/member"
+
+export async function PATCH(req: NextRequest) {
+  let session: Awaited<ReturnType<typeof auth.api.getSession>> | undefined
+  let member: Awaited<ReturnType<InstanceType<typeof AuthService>["getMemberFromUser"]>> | undefined
+
+  try {
+    session = await auth.api.getSession({ headers: req.headers })
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const authService = new AuthService()
+    member = await authService.getMemberFromUser(session.user)
+    if (!member) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 })
+    }
+
+    const body = await req.json()
+    const data = updateMemberSchema.parse(body)
+
+    const effectiveCompsciStudent = data.compsciStudent ?? member.compsciStudent
+    const effectiveOtherMajors = data.otherMajors ?? member.otherMajors
+    if (
+      effectiveCompsciStudent === false &&
+      (!effectiveOtherMajors || effectiveOtherMajors.length === 0)
+    ) {
+      return NextResponse.json(
+        { error: [{ field: "otherMajors", message: "Please enter your major(s)" }] },
+        { status: 400 },
+      )
+    }
+
+    const updated = await authService.updateMember(member.id, data)
+    await authService.updateAuthUser(data, member, req.headers)
+
+    return NextResponse.json(updated, { status: 200 })
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+    if (err instanceof ZodError) {
+      const fieldErrors = err.issues.map((issue) => ({
+        field: issue.path.join("."),
+        message: issue.message,
+      }))
+      return NextResponse.json({ error: fieldErrors }, { status: 400 })
+    }
+    if (err instanceof DuplicateFieldError) {
+      return NextResponse.json(
+        { error: [{ field: err.field, message: "Value already in use" }] },
+        { status: 409 },
+      )
+    }
+    if (err instanceof ValidationError) {
+      const fieldErrors =
+        err.data?.errors?.map((e) => ({ field: e.path ?? "", message: e.message })) ?? []
+      return NextResponse.json({ error: fieldErrors }, { status: 422 })
+    }
+    console.error("[PATCH /api/profile] Unhandled error", {
+      memberId: member?.id,
+      userId: session?.user?.id,
+      error: err,
+    })
+    throw err
+  }
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -28,6 +28,7 @@ export const ApiRoutes = {
     PASS: "/api/google-wallet/pass",
   },
   OG: "/og",
+  PROFILE: "/api/profile",
 } as const
 
 export type ApiRoute = (typeof ApiRoutes)[keyof typeof ApiRoutes]

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -6,7 +6,11 @@ import { auth } from "@/lib/auth"
 import { payload } from "@/lib/payload"
 import { Slugs } from "@/lib/slugs"
 import type { Member } from "@/payload/payload-types"
-import { type CreateMemberInput, createMemberSchema } from "@/types/schemas/member"
+import {
+  type CreateMemberInput,
+  createMemberSchema,
+  type UpdateMemberInput,
+} from "@/types/schemas/member"
 import type { CreateUserInput } from "@/types/schemas/user"
 
 export class DuplicateFieldError extends Error {
@@ -128,6 +132,42 @@ export class AuthService {
         await this.rollbackBetterAuthSignUp(betterAuthUserId)
       }
       throw err
+    }
+  }
+
+  public async updateMember(memberId: string, data: UpdateMemberInput): Promise<Member> {
+    try {
+      return await payload.update({
+        collection: Slugs.Collections.MEMBER,
+        id: memberId,
+        data,
+      })
+    } catch (err) {
+      if (
+        err instanceof ValidationError &&
+        err.data?.errors?.some((e) => e.message === "Value must be unique")
+      ) {
+        const field = err.data.errors.find((e) => e.message === "Value must be unique")?.path ?? ""
+        throw new DuplicateFieldError(field)
+      }
+      console.error("[AuthService] updateMember failed", { memberId, error: err })
+      throw err
+    }
+  }
+
+  public async updateAuthUser(
+    data: UpdateMemberInput,
+    currentMember: Member,
+    headers: Headers,
+  ): Promise<void> {
+    const { firstName, lastName } = data
+    if (firstName !== undefined || lastName !== undefined) {
+      await auth.api.updateUser({
+        headers,
+        body: {
+          name: `${firstName ?? currentMember.firstName} ${lastName ?? currentMember.lastName}`,
+        },
+      })
     }
   }
 

--- a/src/types/schemas/member.ts
+++ b/src/types/schemas/member.ts
@@ -41,3 +41,16 @@ export const createMemberSchema = memberSchema
   })
 
 export type CreateMemberInput = z.infer<typeof createMemberSchema>
+
+export const updateMemberSchema = memberSchema
+  .omit({
+    id: true,
+    createdAt: true,
+    updatedAt: true,
+    email: true,
+    upi: true,
+    uoaID: true,
+  })
+  .partial()
+
+export type UpdateMemberInput = z.infer<typeof updateMemberSchema>


### PR DESCRIPTION
# Description

This PR adds a PATCH /api/profile endpoint that allows authenticated users to update their member profile.

- creates a new `PATCH /api/profile` endpoint that handles member profile updates with authentication validation
- validates update requests against a new `updateMemberSchema` to ensure only allowed fields can be updated (excludes id, timestamps, email, upi, uoaID)
- enforces business logic that users must have at least one major (i.e. can't remove both the CS major and other majors simultaneously)
- updates the member record in Payload CMS via the `updateMember()` method and syncs name changes to the auth user with `updateAuthUser()`
- implements comprehensive error handling covering JSON syntax errors, Zod validation errors, duplicate field errors, and Payload CMS validation errors

Closes #289

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
