### PR TITLE
fix: standardise and include auth ui across site

### DIFF
--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -76,7 +76,7 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
           </p>
           <Button
             className="whitespace-nowrap"
-            left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4 md:h-6 md:w-6" />}
+            left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4" />}
             onClick={async () => {
               try {
                 await authClient.signOut()

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -69,27 +69,25 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
         ) : null}
       </section>
 
-      <section>
-        <div className="flex flex-row justify-between">
-          <p className="font-mono">
-            Signed in as <span className="font-bold">{user.name}</span>
-          </p>
-          <Button
-            className="whitespace-nowrap"
-            left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4" />}
-            onClick={async () => {
-              try {
-                await authClient.signOut()
-              } catch (err) {
-                console.error("[ProfilePageClient] signOut failed", { error: err })
-              }
-              router.push(Routes.LOGIN)
-            }}
-            theme="dark"
-          >
-            Sign Out
-          </Button>
-        </div>
+      <section className="flex flex-col justify-start gap-2 md:flex-row md:justify-between">
+        <p className="font-mono">
+          Signed in as <span className="font-bold">{user.name}</span>
+        </p>
+        <Button
+          className="whitespace-nowrap"
+          left={<ArrowLeftEndOnRectangleIcon className="h-4 w-4" />}
+          onClick={async () => {
+            try {
+              await authClient.signOut()
+            } catch (err) {
+              console.error("[ProfilePageClient] signOut failed", { error: err })
+            }
+            router.push(Routes.LOGIN)
+          }}
+          theme="dark"
+        >
+          Sign Out
+        </Button>
       </section>
     </div>
   )

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -71,7 +71,7 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
 
       <section className="flex flex-col justify-start gap-2 md:flex-row md:justify-between">
         <p className="font-mono">
-          Signed in as <span className="font-bold">{user.name}</span>
+          Logged in as <span className="font-bold">{user.name}</span>
         </p>
         <Button
           className="whitespace-nowrap"
@@ -86,7 +86,7 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
           }}
           theme="dark"
         >
-          Sign Out
+          Log Out
         </Button>
       </section>
     </div>

--- a/src/components/Composite/AboutUsSection/AboutUsSection.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.tsx
@@ -1,6 +1,9 @@
+"use client"
+
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
 import Link from "next/link"
 import { Button } from "@/components/Primitive"
+import { useSession } from "@/context/SessionContext"
 import { Routes } from "@/lib/routes"
 import type { Reel as ReelDocument } from "@/payload/payload-types"
 import { Reel } from "../Reel/Reel"
@@ -25,6 +28,7 @@ export interface AboutUsSectionProps {
  * @param reels An array of reels to display in the About Us section.
  */
 export const AboutUsSection = ({ reels, instagramHref }: AboutUsSectionProps) => {
+  const session = useSession()
   return (
     <div className="flex w-full flex-row justify-between gap-18 overflow-x-visible">
       <div className="flex w-full flex-none flex-col items-center gap-8 md:w-auto md:max-w-lg md:items-start md:gap-12">
@@ -44,11 +48,13 @@ export const AboutUsSection = ({ reels, instagramHref }: AboutUsSectionProps) =>
           competitive events.
         </p>
         <div className="flex flex-col items-center gap-6 md:items-start">
-          <Link className="w-fit" href={Routes.SIGN_UP}>
-            <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
-              Interested? Join UOACS
-            </Button>
-          </Link>
+          {!session && (
+            <Link className="w-fit" href={Routes.SIGN_UP}>
+              <Button right={<ArrowRightIcon className="h-4 w-4 md:h-6 md:w-6" />} theme="dark">
+                Interested? Join UOACS
+              </Button>
+            </Link>
+          )}
           <p className="paragraph-sm font-medium">Membership is 100% free so come join us!</p>
         </div>
       </div>

--- a/src/components/Composite/Footer/Footer.tsx
+++ b/src/components/Composite/Footer/Footer.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { ArrowUpRightIcon } from "@heroicons/react/24/solid"
+import { ArrowUpRightIcon, UserIcon } from "@heroicons/react/24/solid"
 import { motion } from "motion/react"
 import Image from "next/image"
 import Link from "next/link"
 import { useEffect, useRef, useState } from "react"
 import { type SocialLink, SocialLinks } from "@/components/Generic"
 import { Button, SocialIcon } from "@/components/Primitive"
+import { useSession } from "@/context/SessionContext"
 import { Routes } from "@/lib/routes"
 import { cn, shuffle } from "@/lib/utils"
 import type { DiscordWidgetData } from "@/types/schemas/discord"
@@ -36,17 +37,25 @@ export interface FooterProps {
  *
  * @param className optional additional class names to apply to the button
  */
-const InterestedButton = ({ className }: { className?: string }) => (
-  <Link href={Routes.SIGN_UP}>
-    <Button
-      className={cn("whitespace-nowrap", className)}
-      right={<ArrowUpRightIcon className="h-4 w-4 text-white" />}
-      theme="primary"
-    >
-      Interested? Join UOACS
-    </Button>
-  </Link>
-)
+const InterestedButton = ({ className }: { className?: string }) => {
+  const session = useSession()
+  return (
+    <Link href={session ? Routes.PROFILE : Routes.SIGN_UP}>
+      <Button
+        className={cn("whitespace-nowrap", className)}
+        right={
+          !session && (
+            <ArrowUpRightIcon className={cn("h-4 w-4", session ? "text-black" : "text-white")} />
+          )
+        }
+        theme={session ? "light" : "primary"}
+      >
+        {session && <UserIcon className="h-4 w-4" />}
+        {session ? "Profile" : "Interested? Join UOACS"}
+      </Button>
+    </Link>
+  )
+}
 
 /**
  * A footer component for the website, containing links and social media icons.

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -118,12 +118,6 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
             <div className="flex flex-col items-center gap-4">
               {session ? (
                 <div className="flex flex-col items-center justify-center gap-2">
-                  {/*<Link href={Routes.PROFILE}>
-                    <Button className="flex flex-row items-center gap-2" theme="dark">
-                      <UserIcon className="h-4 w-4" />
-                      <p>Profile</p>
-                    </Button>
-                  </Link>*/}
                   <Button
                     className="flex flex-row items-center gap-2"
                     onClick={handleLogout}

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline"
-import { ArrowRightIcon } from "@heroicons/react/24/solid"
+import { ArrowLeftEndOnRectangleIcon, ArrowRightIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion } from "motion/react"
 import Image from "next/image"
 import Link, { type LinkProps } from "next/link"
@@ -25,6 +25,8 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const session = useSession()
   const router = useRouter()
+
+  const extendedLinks = [...links, { label: "Profile", href: Routes.PROFILE }]
 
   const handleLogout = async () => {
     setIsOpen(false)
@@ -102,7 +104,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
               </motion.div>
             </div>
             <div className="w-full">
-              {links.map((link) => (
+              {extendedLinks.map((link) => (
                 <MobileNavbarButton key={link.href} {...link} onClick={() => setIsOpen(false)} />
               ))}
             </div>
@@ -115,31 +117,36 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
             </div>
             <div className="flex flex-col items-center gap-4">
               {session ? (
-                <div className="flex flex-row items-center gap-2">
-                  <Button theme="dark">{session.user.name.split(" ")[0].toUpperCase()}</Button>
-                  <Button onClick={handleLogout} theme="dark">
-                    Logout
+                <div className="flex flex-col items-center justify-center gap-2">
+                  {/*<Link href={Routes.PROFILE}>
+                    <Button className="flex flex-row items-center gap-2" theme="dark">
+                      <UserIcon className="h-4 w-4" />
+                      <p>Profile</p>
+                    </Button>
+                  </Link>*/}
+                  <Button
+                    className="flex flex-row items-center gap-2"
+                    onClick={handleLogout}
+                    theme="dark"
+                  >
+                    <ArrowLeftEndOnRectangleIcon className="h-4 w-4" />
+                    <p>Sign Out</p>
                   </Button>
                 </div>
               ) : (
-                <>
-                  <Link
-                    className="grid grid-cols-4"
-                    href={Routes.SIGN_UP}
-                    onClick={() => setIsOpen(false)}
-                  >
-                    <Button className="col-span-4 rounded-b-none" theme="dark">
-                      Interested? Join UOACS <ArrowRightIcon className="h-3 w-3" />
-                    </Button>
-                    <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
-                    <div className="h-0.5 w-full bg-blue-400" />
-                    <div className="h-0.5 w-full bg-purple-400" />
-                    <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
-                  </Link>
-                  <Link href={Routes.LOGIN} onClick={() => setIsOpen(false)}>
-                    <Button theme="primary">Log In</Button>
-                  </Link>
-                </>
+                <Link
+                  className="grid grid-cols-4"
+                  href={Routes.LOGIN}
+                  onClick={() => setIsOpen(false)}
+                >
+                  <Button className="col-span-4 rounded-b-none" theme="dark">
+                    Log In <ArrowRightIcon className="h-3 w-3" />
+                  </Button>
+                  <div className="h-0.5 w-full rounded-bl-[2px] bg-orange-400" />
+                  <div className="h-0.5 w-full bg-blue-400" />
+                  <div className="h-0.5 w-full bg-purple-400" />
+                  <div className="h-0.5 w-full rounded-br-[2px] bg-pink-400" />
+                </Link>
               )}
             </div>
           </motion.div>

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -124,7 +124,7 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
                     theme="dark"
                   >
                     <ArrowLeftEndOnRectangleIcon className="h-4 w-4" />
-                    <p>Sign Out</p>
+                    <p>Log Out</p>
                   </Button>
                 </div>
               ) : (

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -107,7 +107,7 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
                   label: (
                     <div className="flex flex-row items-center gap-2">
                       <ArrowLeftEndOnRectangleIcon className="h-4 w-4" />
-                      <p>Sign Out</p>
+                      <p>Log Out</p>
                     </div>
                   ),
                   onClick: handleLogout,

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { ArrowUpRightIcon, Bars3Icon } from "@heroicons/react/24/solid"
+import {
+  ArrowLeftEndOnRectangleIcon,
+  ArrowUpRightIcon,
+  Bars3Icon,
+  UserIcon,
+} from "@heroicons/react/24/solid"
 import { motion } from "motion/react"
 import Image from "next/image"
 import Link from "next/link"
@@ -78,16 +83,39 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
               label="Socials"
               options={dropdownOptions}
               theme="primary"
-              triggerClassName="hidden lg:flex"
-              triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
+              trigger={{
+                triggerClassName: "hidden lg:flex",
+                triggerIcon: <Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />,
+              }}
             />
           </div>
           {session ? (
             <Dropdown
-              label={session.user.name.split(" ")[0].toUpperCase()}
-              options={[{ label: "Logout", onClick: handleLogout, theme: "dark" }]}
+              label={<UserIcon className="h-4 w-4" />}
+              options={[
+                {
+                  label: (
+                    <div className="flex flex-row items-center gap-2">
+                      <UserIcon className="h-4 w-4" />
+                      <p>Profile</p>
+                    </div>
+                  ),
+                  href: Routes.PROFILE,
+                  theme: "dark",
+                },
+                {
+                  label: (
+                    <div className="flex flex-row items-center gap-2">
+                      <ArrowLeftEndOnRectangleIcon className="h-4 w-4" />
+                      <p>Sign Out</p>
+                    </div>
+                  ),
+                  onClick: handleLogout,
+                  theme: "dark",
+                },
+              ]}
               theme="dark"
-              triggerIcon={<Bars3Icon className="h-4 w-4 md:h-6 md:w-6" />}
+              trigger={false}
             />
           ) : (
             <Link href={Routes.LOGIN}>

--- a/src/components/Primitive/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.stories.tsx
@@ -8,9 +8,8 @@ const meta: Meta<typeof Dropdown> = {
   argTypes: {
     label: { control: "text" },
     options: { control: "object" },
-    triggerClassName: { control: "text" },
     popoverClassName: { control: "text" },
-    triggerIcon: { control: false },
+    trigger: { control: false },
   },
   args: {
     label: "Socials",
@@ -34,10 +33,13 @@ export const Primary: Story = {}
 
 export const TriggerIcon: Story = {
   args: {
-    triggerIcon: <Bars3Icon className="h-6 w-6 text-white" />,
+    trigger: { triggerIcon: <Bars3Icon className="h-6 w-6 text-white" /> },
   },
-  argTypes: {
-    triggerIcon: { control: false },
+}
+
+export const NoTriggerIcon: Story = {
+  args: {
+    trigger: false,
   },
 }
 

--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -14,7 +14,7 @@ export interface DropdownProps extends ButtonVariantProps {
   /**
    * A label for the dropdown button.
    */
-  label: string
+  label: string | ReactNode
   /**
    * Options for the dropdown menu.
    */
@@ -24,14 +24,10 @@ export interface DropdownProps extends ButtonVariantProps {
    */
   popoverClassName?: string
   /**
-   * Additional class names for the trigger button.
+   * Trigger button configuration, or `false` to hide the trigger icon entirely.
+   * Omit for default triangle icon.
    */
-  triggerClassName?: string
-  /**
-   * Optional icon for the trigger button.
-   * If not supplied, falls back to default icon.
-   */
-  triggerIcon?: ReactNode
+  trigger?: false | { triggerClassName?: string; triggerIcon?: ReactNode }
 }
 
 /**
@@ -44,8 +40,7 @@ export const Dropdown = ({
   label,
   options,
   popoverClassName,
-  triggerClassName,
-  triggerIcon,
+  trigger,
   ...buttonVariantProps
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -66,30 +61,34 @@ export const Dropdown = ({
     }
   }, [])
 
+  const triggerClassName = trigger !== false ? trigger?.triggerClassName : undefined
+  const triggerRight =
+    trigger === false
+      ? undefined
+      : (trigger?.triggerIcon ?? (
+          <svg
+            className={cn("transition-transform duration-200", isOpen && "rotate-180")}
+            fill="none"
+            height="9"
+            viewBox="0 0 11 9"
+            width="11"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>Toggle dropdown</title>
+            <path
+              d="M5.91805 8.775C5.73225 9.075 5.26775 9.075 5.08195 8.775L0.0653922 0.675C-0.120406 0.375 0.111842 -3.02841e-08 0.483439 0L10.5166 8.17672e-07C10.8882 8.47956e-07 11.1204 0.375001 10.9346 0.675001L5.91805 8.775Z"
+              fill="currentColor"
+            />
+          </svg>
+        ))
+
   return (
     <div className="relative inline-flex" ref={ref}>
       <Button
         aria-expanded={isOpen}
         className={cn("z-20", triggerClassName)}
         onClick={() => setIsOpen(!isOpen)}
-        right={
-          triggerIcon || (
-            <svg
-              className={cn("transition-transform duration-200", isOpen && "rotate-180")}
-              fill="none"
-              height="9"
-              viewBox="0 0 11 9"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <title>Toggle dropdown</title>
-              <path
-                d="M5.91805 8.775C5.73225 9.075 5.26775 9.075 5.08195 8.775L0.0653922 0.675C-0.120406 0.375 0.111842 -3.02841e-08 0.483439 0L10.5166 8.17672e-07C10.8882 8.47956e-07 11.1204 0.375001 10.9346 0.675001L5.91805 8.775Z"
-                fill="currentColor"
-              />
-            </svg>
-          )
-        }
+        right={triggerRight}
         {...buttonVariantProps}
       >
         {label}

--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { ChevronDownIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion, stagger } from "motion/react"
 import { type ReactNode, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
@@ -66,20 +67,7 @@ export const Dropdown = ({
     trigger === false
       ? undefined
       : (trigger?.triggerIcon ?? (
-          <svg
-            className={cn("transition-transform duration-200", isOpen && "rotate-180")}
-            fill="none"
-            height="9"
-            viewBox="0 0 11 9"
-            width="11"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>Toggle dropdown</title>
-            <path
-              d="M5.91805 8.775C5.73225 9.075 5.26775 9.075 5.08195 8.775L0.0653922 0.675C-0.120406 0.375 0.111842 -3.02841e-08 0.483439 0L10.5166 8.17672e-07C10.8882 8.47956e-07 11.1204 0.375001 10.9346 0.675001L5.91805 8.775Z"
-              fill="currentColor"
-            />
-          </svg>
+          <ChevronDownIcon className={cn("h-4 w-4", isOpen && "rotate-180")} />
         ))
 
   return (

--- a/src/components/Primitive/Dropdown/DropdownOption.tsx
+++ b/src/components/Primitive/Dropdown/DropdownOption.tsx
@@ -30,8 +30,14 @@ export interface DropdownOptionProps extends ButtonVariantProps {
 export const DropdownOption = ({ label, href, onClick, ...variant }: DropdownOptionProps) => {
   if (href) {
     const variantClasses = buttonVariants(variant)
+    const isExternal = href.startsWith("http")
     return (
-      <Link href={href} rel="noopener noreferrer" role="menuitem" target="_blank">
+      <Link
+        href={href}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        role="menuitem"
+        target={isExternal ? "_blank" : "_self"}
+      >
         <div className={cn(variantClasses, "whitespace-nowrap")}>{label || "Option"}</div>
       </Link>
     )


### PR DESCRIPTION
# Description

This PR improves auth-related UI consistency across the site — standardising "log in/out" terminology, refining the authenticated navbar and mobile navbar states, making the footer CTA session-aware, and hiding the "Interested? Join UOACS" button when already logged in.

- updates `Dropdown` to consolidate `triggerClassName` and `triggerIcon` into a single `trigger` prop, supporting `false` to hide the trigger icon entirely
  - replaces the custom SVG triangle with `ChevronDownIcon` from heroicons
- updates `Navbar` authenticated dropdown to show a `UserIcon` label with `Profile` and `Log Out` options (replacing the first-name + logout button)
- simplifies `MobileNavbar` authenticated state to a single `Log Out` button and adds `Profile` to the nav links
- makes `Footer`'s `InterestedButton` session-aware — links to `/profile` with a `Profile` label when logged in, otherwise shows the join CTA
- hides the "Interested? Join UOACS" button in `AboutUsSection` when logged in
- fixes `DropdownOption` to only open external links in a new tab
- standardises icon sizes and "log in/log out" copy across all auth UI

Closes #293 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member