### PR TITLE
feat(auth): add GuestOnly and UserOnly wrappers for auth guarding

### DIFF
--- a/src/app/(frontend)/_components/GuestOnly.tsx
+++ b/src/app/(frontend)/_components/GuestOnly.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { type ReactNode, useEffect } from "react"
+import { useSession } from "@/context/SessionContext"
+import { Routes } from "@/lib/routes"
+
+export const GuestOnly = ({
+  children,
+  fallback = null,
+}: {
+  children: ReactNode
+  fallback?: ReactNode
+}) => {
+  const session = useSession()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (session) {
+      router.replace(Routes.HOME)
+    }
+  }, [session, router])
+
+  if (session === null) return children
+  return fallback
+}

--- a/src/app/(frontend)/_components/UserOnly.tsx
+++ b/src/app/(frontend)/_components/UserOnly.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { type ReactNode, useEffect } from "react"
+import { useSession } from "@/context/SessionContext"
+import { Routes } from "@/lib/routes"
+
+export const UserOnly = ({
+  children,
+  fallback = null,
+}: {
+  children: ReactNode
+  fallback?: ReactNode
+}) => {
+  const session = useSession()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (session === null) {
+      router.replace(Routes.LOGIN)
+    }
+  }, [session, router])
+
+  if (session === null) return fallback
+  return children
+}

--- a/src/app/(frontend)/login/page.tsx
+++ b/src/app/(frontend)/login/page.tsx
@@ -1,13 +1,16 @@
 import { LoginForm } from "@/components/Composite"
 import { Heading } from "@/components/Primitive"
+import { GuestOnly } from "../_components/GuestOnly"
 
 export default function LoginPage() {
   return (
-    <div className="flex w-full flex-col justify-center gap-8 px-4">
-      <Heading className="justify-start" h={3}>
-        Log In
-      </Heading>
-      <LoginForm />
-    </div>
+    <GuestOnly>
+      <div className="flex w-full flex-col justify-center gap-8 px-4">
+        <Heading className="justify-start" h={3}>
+          Log In
+        </Heading>
+        <LoginForm />
+      </div>
+    </GuestOnly>
   )
 }

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -2,10 +2,8 @@
 
 import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/solid"
 import type { User } from "better-auth"
-import { useRouter } from "next/navigation"
 import { Button, Heading } from "@/components/Primitive"
 import { authClient } from "@/lib/auth-client"
-import { Routes } from "@/lib/routes"
 import { useMember } from "@/queries/useMember"
 import { MemberDetailsForm } from "./MemberDetailsForm"
 
@@ -15,7 +13,6 @@ export type ProfilePageClientProps = {
 
 export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
   const { data: member, isLoading, isError } = useMember(user.id)
-  const router = useRouter()
 
   return (
     <div className="flex w-full flex-col gap-12">
@@ -82,7 +79,6 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
             } catch (err) {
               console.error("[ProfilePageClient] signOut failed", { error: err })
             }
-            router.push(Routes.LOGIN)
           }}
           theme="dark"
         >

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -1,10 +1,15 @@
 import { redirect } from "next/navigation"
 import { getSession } from "@/lib/auth-session"
 import { Routes } from "@/lib/routes"
+import { UserOnly } from "../_components/UserOnly"
 import { ProfilePageClient } from "./_components/ProfilePageClient"
 
 export default async function ProfilePage() {
   const session = await getSession()
   if (!session) redirect(Routes.LOGIN)
-  return <ProfilePageClient user={session.user} />
+  return (
+    <UserOnly>
+      <ProfilePageClient user={session.user} />
+    </UserOnly>
+  )
 }

--- a/src/app/(frontend)/sign-up/page.tsx
+++ b/src/app/(frontend)/sign-up/page.tsx
@@ -2,22 +2,25 @@ import Link from "next/link"
 import { SignUpForm } from "@/components/Composite"
 import { Heading } from "@/components/Primitive"
 import { Routes } from "@/lib/routes"
+import { GuestOnly } from "../_components/GuestOnly"
 
 export default function SignUpPage() {
   return (
-    <div className="flex w-full flex-col justify-center gap-8 px-4">
-      <Heading className="justify-start" h={3}>
-        Sign Up
-      </Heading>
-      <div className="flex w-full flex-col justify-center gap-4">
-        <SignUpForm />
-        <p className="paragraph-xs text-gray-500">
-          Already Signed Up?{" "}
-          <Link className="underline transition-colors hover:text-gray-700" href={Routes.LOGIN}>
-            Log In
-          </Link>
-        </p>
+    <GuestOnly>
+      <div className="flex w-full flex-col justify-center gap-8 px-4">
+        <Heading className="justify-start" h={3}>
+          Sign Up
+        </Heading>
+        <div className="flex w-full flex-col justify-center gap-4">
+          <SignUpForm />
+          <p className="paragraph-xs text-gray-500">
+            Already Signed Up?{" "}
+            <Link className="underline transition-colors hover:text-gray-700" href={Routes.LOGIN}>
+              Log In
+            </Link>
+          </p>
+        </div>
       </div>
-    </div>
+    </GuestOnly>
   )
 }

--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -31,7 +31,6 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
   const handleLogout = async () => {
     setIsOpen(false)
     await authClient.signOut()
-    router.push(Routes.HOME)
     router.refresh()
   }
 

--- a/src/components/Composite/Navbar/Navbar.tsx
+++ b/src/components/Composite/Navbar/Navbar.tsx
@@ -46,7 +46,6 @@ export function Navbar({ links, socialLinks }: NavbarProps) {
 
   const handleLogout = async () => {
     await authClient.signOut()
-    router.push(Routes.HOME)
     router.refresh()
   }
 


### PR DESCRIPTION
# Description

This PR introduces `GuestOnly` and `UserOnly` wrapper components for consistent, declarative auth-based route guarding across the app.

- adds `GuestOnly` component that redirects authenticated users to home
- adds `UserOnly` component that redirects unauthenticated users to login
- wraps `LoginPage` and `SignUpPage` with `GuestOnly` to prevent logged-in users from accessing auth pages
- wraps `ProfilePage` content with `UserOnly` as a client-side guard alongside the existing server-side `redirect`
- removes manual `router.push(Routes.LOGIN)` from `ProfilePageClient` — now handled by `UserOnly`
- removes stale `router.push(Routes.HOME)` calls from `Navbar` and `MobileNavbar` on log out

Closes #293

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
