### PR TITLE
feat(profile): implement member profile update flow

### DIFF
--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -3,7 +3,10 @@
 import { useState } from "react"
 import { ToggleableInput } from "@/components/Generic"
 import { Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import { toast } from "@/lib/toast"
 import type { Member } from "@/payload/payload-types"
+import { ProfileUpdateError, useUpdateMember } from "@/queries/useUpdateMember"
+import type { UpdateMemberInput } from "@/types/schemas/member"
 
 const STUDY_YEAR_OPTIONS = [
   { label: "First Year", value: "first-year" },
@@ -36,17 +39,48 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
   const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
   const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
 
-  const handleSave = () => {
-    // TODO: persist field update
+  const [errors, setErrors] = useState<Partial<Record<keyof UpdateMemberInput, string>>>({})
+  const { mutateAsync } = useUpdateMember()
+
+  const saveField = async <K extends keyof UpdateMemberInput>(
+    field: K,
+    value: UpdateMemberInput[K],
+  ) => {
+    setErrors((prev) => ({ ...prev, [field]: undefined }))
+    try {
+      await mutateAsync({ [field]: value } as Partial<UpdateMemberInput>)
+      toast.success({ description: "Profile updated" })
+    } catch (err) {
+      const fieldError =
+        err instanceof ProfileUpdateError
+          ? err.fieldErrors.find((e) => e.field === field)
+          : undefined
+      if (fieldError) {
+        setErrors((prev) => ({ ...prev, [field]: fieldError.message }))
+      } else {
+        toast.error({ description: "An error occurred while updating your profile" })
+      }
+      throw err
+    }
   }
 
   return (
     <div className="flex w-full flex-col items-start gap-4">
-      <ToggleableInput displayNode={firstName} label="First Name" onSave={handleSave}>
+      <ToggleableInput
+        displayNode={firstName}
+        error={errors.firstName}
+        label="First Name"
+        onSave={() => saveField("firstName", firstName)}
+      >
         <Input onChange={(e) => setFirstName(e.target.value)} type="text" value={firstName} />
       </ToggleableInput>
 
-      <ToggleableInput displayNode={lastName} label="Last Name" onSave={handleSave}>
+      <ToggleableInput
+        displayNode={lastName}
+        error={errors.lastName}
+        label="Last Name"
+        onSave={() => saveField("lastName", lastName)}
+      >
         <Input onChange={(e) => setLastName(e.target.value)} type="text" value={lastName} />
       </ToggleableInput>
 
@@ -77,7 +111,12 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
       </ToggleableInput>
 
-      <ToggleableInput displayNode={gender} label="Gender" onSave={handleSave}>
+      <ToggleableInput
+        displayNode={gender}
+        error={errors.gender}
+        label="Gender"
+        onSave={() => saveField("gender", gender as UpdateMemberInput["gender"])}
+      >
         <Select
           onChange={setGender}
           options={["Male", "Female", "Other", "Prefer not to say"]}
@@ -85,14 +124,20 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         />
       </ToggleableInput>
 
-      <ToggleableInput displayNode={phoneNumber} label="Phone Number" onSave={handleSave}>
+      <ToggleableInput
+        displayNode={phoneNumber}
+        error={errors.phoneNumber}
+        label="Phone Number"
+        onSave={() => saveField("phoneNumber", phoneNumber)}
+      >
         <Input onChange={(e) => setPhoneNumber(e.target.value)} type="text" value={phoneNumber} />
       </ToggleableInput>
 
       <ToggleableInput
         displayNode={compsciStudent ?? ""}
+        error={errors.compsciStudent}
         label="Are you a computer science student?"
-        onSave={handleSave}
+        onSave={() => saveField("compsciStudent", compsciStudent === "Yes")}
       >
         <Radio
           onChange={setCompsciStudent}
@@ -104,16 +149,18 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
 
       <ToggleableInput
         displayNode={STUDY_YEAR_OPTIONS.find((o) => o.value === studyYear)?.label ?? studyYear}
+        error={errors.studyYear}
         label="Year of Study"
-        onSave={handleSave}
+        onSave={() => saveField("studyYear", studyYear as UpdateMemberInput["studyYear"])}
       >
         <Select onChange={setStudyYear} options={STUDY_YEAR_OPTIONS} value={studyYear} />
       </ToggleableInput>
 
       <ToggleableInput
         displayNode={otherMajors.join(", ")}
+        error={errors.otherMajors}
         label={compsciStudent === "Yes" ? "Other Majors (if any)" : "Other Majors"}
-        onSave={handleSave}
+        onSave={() => saveField("otherMajors", otherMajors)}
       >
         <MultiSelect
           customTextInput
@@ -125,16 +172,18 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
 
       <ToggleableInput
         displayNode={heardAboutUs}
+        error={errors.heardAboutUs}
         label="How did you hear about us?"
-        onSave={handleSave}
+        onSave={() => saveField("heardAboutUs", heardAboutUs)}
       >
         <Input onChange={(e) => setHeardAboutUs(e.target.value)} type="text" value={heardAboutUs} />
       </ToggleableInput>
 
       <ToggleableInput
         displayNode={eventWishlist}
+        error={errors.eventWishList}
         label="What kinds of events would you like to see us host?"
-        onSave={handleSave}
+        onSave={() => saveField("eventWishList", eventWishlist)}
       >
         <Input
           onChange={(e) => setEventWishlist(e.target.value)}

--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -51,17 +51,33 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
       await mutateAsync({ [field]: value } as Partial<UpdateMemberInput>)
       toast.success({ description: "Profile updated" })
     } catch (err) {
-      const fieldError =
-        err instanceof ProfileUpdateError
-          ? err.fieldErrors.find((e) => e.field === field)
-          : undefined
-      if (fieldError) {
-        setErrors((prev) => ({ ...prev, [field]: fieldError.message }))
+      if (err instanceof ProfileUpdateError && err.fieldErrors.length > 0) {
+        setErrors((prev) => {
+          const next = { ...prev }
+          for (const fieldError of err.fieldErrors) {
+            next[fieldError.field] = fieldError.message
+          }
+          return next
+        })
+        if (!err.fieldErrors.some((fieldError) => fieldError.field === field)) {
+          toast.error({ description: err.message })
+        }
       } else {
-        toast.error({ description: "An error occurred while updating your profile" })
+        console.error("[MemberDetailsForm] saveField failed", { field, error: err })
+        toast.error({
+          description:
+            err instanceof ProfileUpdateError
+              ? err.message
+              : "An error occurred while updating your profile",
+        })
       }
       throw err
     }
+  }
+
+  const cancelField = <K extends keyof UpdateMemberInput>(field: K, reset: () => void) => {
+    reset()
+    setErrors((prev) => ({ ...prev, [field]: undefined }))
   }
 
   return (
@@ -70,6 +86,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={firstName}
         error={errors.firstName}
         label="First Name"
+        onCancel={() => cancelField("firstName", () => setFirstName(member.firstName ?? ""))}
         onSave={() => saveField("firstName", firstName)}
       >
         <Input onChange={(e) => setFirstName(e.target.value)} type="text" value={firstName} />
@@ -79,6 +96,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={lastName}
         error={errors.lastName}
         label="Last Name"
+        onCancel={() => cancelField("lastName", () => setLastName(member.lastName ?? ""))}
         onSave={() => saveField("lastName", lastName)}
       >
         <Input onChange={(e) => setLastName(e.target.value)} type="text" value={lastName} />
@@ -115,6 +133,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={gender}
         error={errors.gender}
         label="Gender"
+        onCancel={() => cancelField("gender", () => setGender(member.gender ?? ""))}
         onSave={() => saveField("gender", gender as UpdateMemberInput["gender"])}
       >
         <Select
@@ -128,6 +147,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={phoneNumber}
         error={errors.phoneNumber}
         label="Phone Number"
+        onCancel={() => cancelField("phoneNumber", () => setPhoneNumber(member.phoneNumber ?? ""))}
         onSave={() => saveField("phoneNumber", phoneNumber)}
       >
         <Input onChange={(e) => setPhoneNumber(e.target.value)} type="text" value={phoneNumber} />
@@ -137,6 +157,17 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={compsciStudent ?? ""}
         error={errors.compsciStudent}
         label="Are you a computer science student?"
+        onCancel={() =>
+          cancelField("compsciStudent", () =>
+            setCompsciStudent(
+              member.compsciStudent === true
+                ? "Yes"
+                : member.compsciStudent === false
+                  ? "No"
+                  : undefined,
+            ),
+          )
+        }
         onSave={() => saveField("compsciStudent", compsciStudent === "Yes")}
       >
         <Radio
@@ -151,6 +182,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={STUDY_YEAR_OPTIONS.find((o) => o.value === studyYear)?.label ?? studyYear}
         error={errors.studyYear}
         label="Year of Study"
+        onCancel={() => cancelField("studyYear", () => setStudyYear(member.studyYear ?? ""))}
         onSave={() => saveField("studyYear", studyYear as UpdateMemberInput["studyYear"])}
       >
         <Select onChange={setStudyYear} options={STUDY_YEAR_OPTIONS} value={studyYear} />
@@ -160,6 +192,7 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={otherMajors.join(", ")}
         error={errors.otherMajors}
         label={compsciStudent === "Yes" ? "Other Majors (if any)" : "Other Majors"}
+        onCancel={() => cancelField("otherMajors", () => setOtherMajors(member.otherMajors ?? []))}
         onSave={() => saveField("otherMajors", otherMajors)}
       >
         <MultiSelect
@@ -174,6 +207,9 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={heardAboutUs}
         error={errors.heardAboutUs}
         label="How did you hear about us?"
+        onCancel={() =>
+          cancelField("heardAboutUs", () => setHeardAboutUs(member.heardAboutUs ?? ""))
+        }
         onSave={() => saveField("heardAboutUs", heardAboutUs)}
       >
         <Input onChange={(e) => setHeardAboutUs(e.target.value)} type="text" value={heardAboutUs} />
@@ -183,6 +219,9 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         displayNode={eventWishlist}
         error={errors.eventWishList}
         label="What kinds of events would you like to see us host?"
+        onCancel={() =>
+          cancelField("eventWishList", () => setEventWishlist(member.eventWishList ?? ""))
+        }
         onSave={() => saveField("eventWishList", eventWishlist)}
       >
         <Input

--- a/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
+++ b/src/app/(frontend)/profile/_components/ProfilePageClient.tsx
@@ -13,6 +13,7 @@ export type ProfilePageClientProps = {
 
 export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
   const { data: member, isLoading, isError } = useMember(user.id)
+  const displayName = `${member?.firstName ?? ""} ${member?.lastName ?? ""}`.trim() || user.name
 
   return (
     <div className="flex w-full flex-col gap-12">
@@ -22,7 +23,7 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
           <span className="text-primary">// </span>YOUR ACCOUNT
         </p>
         <Heading h={2} period>
-          {user.name}
+          {displayName}
         </Heading>
         <p className="flex flex-row justify-start gap-2 font-mono text-paragraph-sm">
           <span>
@@ -68,7 +69,7 @@ export const ProfilePageClient = ({ user }: ProfilePageClientProps) => {
 
       <section className="flex flex-col justify-start gap-2 md:flex-row md:justify-between">
         <p className="font-mono">
-          Logged in as <span className="font-bold">{user.name}</span>
+          Logged in as <span className="font-bold">{displayName}</span>
         </p>
         <Button
           className="whitespace-nowrap"

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -213,8 +213,8 @@ export const MemberStep = () => {
       />
 
       <Input
-        {...register("eventWishlist")}
-        error={errors.eventWishlist?.message}
+        {...register("eventWishList")}
+        error={errors.eventWishList?.message}
         label="What kinds of events would you like to see us host?"
         type="text"
       />

--- a/src/components/Generic/ToggleableInput/ToggleableInput.tsx
+++ b/src/components/Generic/ToggleableInput/ToggleableInput.tsx
@@ -13,6 +13,7 @@ export interface ToggleableProps {
   containerClassName?: string
   displayNode: React.ReactNode
   onSave?: () => void | Promise<void>
+  onCancel?: () => void
   defaultToggleState?: boolean
   locked?: boolean
   lockedReason?: string
@@ -26,6 +27,7 @@ export const ToggleableInput = ({
   containerClassName,
   displayNode,
   onSave,
+  onCancel,
   defaultToggleState = false,
   locked = false,
   lockedReason,
@@ -81,7 +83,10 @@ export const ToggleableInput = ({
                     <div className="flex flex-row gap-2">
                       <Button
                         className="h-auto px-2 py-1 text-xs leading-none md:h-auto"
-                        onClick={() => setIsEditable(false)}
+                        onClick={() => {
+                          onCancel?.()
+                          setIsEditable(false)
+                        }}
                         theme="ghost"
                       >
                         Close
@@ -94,8 +99,8 @@ export const ToggleableInput = ({
                           try {
                             await onSave?.()
                             setIsEditable(false)
-                          } catch {
-                            // stay open — parent sets error prop on failure
+                          } catch (err) {
+                            console.error("[ToggleableInput] onSave failed", { label, error: err })
                           } finally {
                             setIsSaving(false)
                           }

--- a/src/queries/useUpdateMember.ts
+++ b/src/queries/useUpdateMember.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { ApiRoutes } from "@/lib/routes"
+import type { Member } from "@/payload/payload-types"
+import type { UpdateMemberInput } from "@/types/schemas/member"
+import { QueryKeys } from "./QueryKeys"
+
+export type ProfileFieldError = { field: string; message: string }
+
+export class ProfileUpdateError extends Error {
+  constructor(public readonly fieldErrors: ProfileFieldError[]) {
+    super("Failed to update profile")
+    this.name = "ProfileUpdateError"
+  }
+}
+
+export function useUpdateMember() {
+  const queryClient = useQueryClient()
+
+  return useMutation<Member, ProfileUpdateError, Partial<UpdateMemberInput>>({
+    mutationFn: async (data) => {
+      const response = await fetch(ApiRoutes.PROFILE, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => null)
+        const fieldErrors: ProfileFieldError[] = Array.isArray(body?.error) ? body.error : []
+        throw new ProfileUpdateError(fieldErrors)
+      }
+      return response.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.MEMBER] })
+    },
+  })
+}

--- a/src/queries/useUpdateMember.ts
+++ b/src/queries/useUpdateMember.ts
@@ -4,11 +4,14 @@ import type { Member } from "@/payload/payload-types"
 import type { UpdateMemberInput } from "@/types/schemas/member"
 import { QueryKeys } from "./QueryKeys"
 
-export type ProfileFieldError = { field: string; message: string }
+export type ProfileFieldError = { field: keyof UpdateMemberInput; message: string }
 
 export class ProfileUpdateError extends Error {
-  constructor(public readonly fieldErrors: ProfileFieldError[]) {
-    super("Failed to update profile")
+  constructor(
+    public readonly fieldErrors: ProfileFieldError[],
+    message = "Failed to update profile",
+  ) {
+    super(message)
     this.name = "ProfileUpdateError"
   }
 }
@@ -25,10 +28,15 @@ export function useUpdateMember() {
       })
       if (!response.ok) {
         const body = await response.json().catch(() => null)
-        const fieldErrors: ProfileFieldError[] = Array.isArray(body?.error) ? body.error : []
-        throw new ProfileUpdateError(fieldErrors)
+        if (Array.isArray(body?.error)) {
+          throw new ProfileUpdateError(body.error)
+        }
+        const message = typeof body?.error === "string" ? body.error : undefined
+        throw new ProfileUpdateError([], message)
       }
-      return response.json()
+      return response.json().catch(() => {
+        throw new ProfileUpdateError([], "Received an invalid response from the server")
+      })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.MEMBER] })

--- a/src/types/schemas/member.ts
+++ b/src/types/schemas/member.ts
@@ -23,7 +23,7 @@ export const memberSchema = z.object({
     },
   ),
   heardAboutUs: z.string().min(1, "This field is required"),
-  eventWishlist: z.string().nullable().optional(),
+  eventWishList: z.string().nullable().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 }) satisfies z.ZodType<Member>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR wires the profile edit form up to `useUpdateMember`, replacing the stubbed `handleSave` with a real PATCH request to `ApiRoutes.PROFILE`.

- adds `onCancel` support to `ToggleableInput` so cancelling an edit resets the field back to its saved value instead of leaving the input dirty
- adds `useUpdateMember()` mutation hook in `src/queries/useUpdateMember.ts`, which throws a `ProfileUpdateError` (carrying per-field errors) on failure and invalidates the `MEMBER` query on success
- surfaces per-field validation errors on each `ToggleableInput` via a local `errors` state in `MemberDetailsForm`, and falls back to a toast for non-field errors
- fixes `ProfilePageClient` to display the member's `firstName`/`lastName` instead of `user.name`
- renames `eventWishlist` to `eventWishList` across the member schema, `MemberStep`, and `MemberDetailsForm` to match the Payload collection field (i.e. was silently failing to save previously due to the mismatch)
- logs `onSave` failures to console in `ToggleableInput` (previously swallowed silently)

Not related to a ticket

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)