### PR TITLE
feat(payload): add Event collection

### DIFF
--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,6 +7,7 @@ export const Routes = {
   SIGN_UP: "/sign-up",
   LOGIN: "/login",
   GOOGLE_WALLET: "/google-wallet",
+  EVENTS: "/events",
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]

--- a/src/lib/slugs.ts
+++ b/src/lib/slugs.ts
@@ -8,6 +8,7 @@ export const Slugs = {
     SPONSOR: "sponsor",
     ADMIN: "admin",
     EMAIL_VERIFICATION_CODE: "email-verification-code",
+    EVENT: "event",
   },
   Globals: {
     HOME_PAGE: "home-page",

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,6 +10,7 @@ import sharp from "sharp"
 import { Slugs } from "./lib/slugs"
 import { Admin } from "./payload/collections/Admin"
 import { EmailVerificationCode } from "./payload/collections/EmailVerificationCode"
+import { Event } from "./payload/collections/Event"
 import { Executive } from "./payload/collections/Executive"
 import { Media } from "./payload/collections/Media"
 import { Member } from "./payload/collections/Member"
@@ -31,7 +32,17 @@ export default buildConfig({
       importMapFile: `${path.resolve(dirname)}/app/payload/admin/importMap.js`,
     },
   },
-  collections: [Admin, Media, Member, Executive, Sponsor, Reel, Polaroid, EmailVerificationCode],
+  collections: [
+    Admin,
+    Media,
+    Member,
+    Executive,
+    Sponsor,
+    Reel,
+    Polaroid,
+    EmailVerificationCode,
+    Event,
+  ],
   globals: [HomePage, PrivacyPolicy, SocialLinks],
   editor: lexicalEditor(),
   graphQL: {

--- a/src/payload/collections/Event.ts
+++ b/src/payload/collections/Event.ts
@@ -58,7 +58,7 @@ export const Event: CollectionConfig = {
       },
     },
     {
-      name: "sign-up-form",
+      name: "signUpForm",
       type: "text",
       required: false, // once sign up is integrated to the website, new events can leave this field blank and be routed to internal sign up
       admin: {

--- a/src/payload/collections/Event.ts
+++ b/src/payload/collections/Event.ts
@@ -1,0 +1,71 @@
+import type { CollectionConfig } from "payload"
+import { Routes } from "@/lib/routes"
+import { Slugs } from "@/lib/slugs"
+import { makeRevalidateHooks } from "../hooks/revalidate"
+
+const { afterChange, afterDelete } = makeRevalidateHooks([Routes.EVENTS])
+
+export const Event: CollectionConfig = {
+  slug: Slugs.Collections.EVENT,
+  admin: {
+    useAsTitle: "name",
+  },
+  versions: {
+    drafts: true,
+  },
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      required: true,
+      admin: {
+        description: "Name of the event",
+      },
+    },
+    {
+      name: "description",
+      type: "text",
+      required: false,
+      admin: {
+        description: "Short description of the event",
+      },
+    },
+    {
+      name: "date",
+      type: "date",
+      required: true,
+      index: true,
+      admin: {
+        description: "Date that the event is being run",
+      },
+    },
+    {
+      name: "time",
+      type: "text",
+      required: true,
+      index: true,
+      admin: {
+        description: "Time that the event is being run",
+      },
+    },
+    {
+      name: "design",
+      type: "relationship",
+      relationTo: "media",
+      required: true,
+      admin: {
+        description: "The image posted to socials for this event and to be shown on the site",
+      },
+    },
+    {
+      name: "sign-up-form",
+      type: "text",
+      required: false, // once sign up is integrated to the website, new events can leave this field blank and be routed to internal sign up
+      admin: {
+        description:
+          "Link to the google form for this event. Do not include when retroactively adding events.",
+      },
+    },
+  ],
+  hooks: { afterChange: [afterChange], afterDelete: [afterDelete] },
+}

--- a/src/payload/collections/Event.ts
+++ b/src/payload/collections/Event.ts
@@ -36,16 +36,10 @@ export const Event: CollectionConfig = {
       required: true,
       index: true,
       admin: {
-        description: "Date that the event is being run",
-      },
-    },
-    {
-      name: "time",
-      type: "text",
-      required: true,
-      index: true,
-      admin: {
-        description: "Time that the event is being run",
+        description: "Date and time that the event is being run",
+        date: {
+          pickerAppearance: "dayAndTime",
+        },
       },
     },
     {

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -397,7 +397,7 @@ export interface Event {
   /**
    * Link to the google form for this event. Do not include when retroactively adding events.
    */
-  'sign-up-form'?: string | null;
+  signUpForm?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -804,7 +804,7 @@ export interface EventSelect<T extends boolean = true> {
   date?: T;
   time?: T;
   design?: T;
-  'sign-up-form'?: T;
+  signUpForm?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     reel: Reel;
     polaroid: Polaroid;
     'email-verification-code': EmailVerificationCode;
+    event: Event;
     exports: Export;
     imports: Import;
     'payload-kv': PayloadKv;
@@ -93,6 +94,7 @@ export interface Config {
     reel: ReelSelect<false> | ReelSelect<true>;
     polaroid: PolaroidSelect<false> | PolaroidSelect<true>;
     'email-verification-code': EmailVerificationCodeSelect<false> | EmailVerificationCodeSelect<true>;
+    event: EventSelect<false> | EventSelect<true>;
     exports: ExportsSelect<false> | ExportsSelect<true>;
     imports: ImportsSelect<false> | ImportsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -368,6 +370,40 @@ export interface EmailVerificationCode {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "event".
+ */
+export interface Event {
+  id: string;
+  /**
+   * Name of the event
+   */
+  name: string;
+  /**
+   * Short description of the event
+   */
+  description?: string | null;
+  /**
+   * Date that the event is being run
+   */
+  date: string;
+  /**
+   * Time that the event is being run
+   */
+  time: string;
+  /**
+   * The image posted to socials for this event and to be shown on the site
+   */
+  design: string | Media;
+  /**
+   * Link to the google form for this event. Do not include when retroactively adding events.
+   */
+  'sign-up-form'?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "exports".
  */
 export interface Export {
@@ -587,6 +623,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'email-verification-code';
         value: string | EmailVerificationCode;
+      } | null)
+    | ({
+        relationTo: 'event';
+        value: string | Event;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -753,6 +793,21 @@ export interface EmailVerificationCodeSelect<T extends boolean = true> {
   expiresAt?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "event_select".
+ */
+export interface EventSelect<T extends boolean = true> {
+  name?: T;
+  description?: T;
+  date?: T;
+  time?: T;
+  design?: T;
+  'sign-up-form'?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -991,6 +1046,7 @@ export interface TaskCreateCollectionExport {
       | 'reel'
       | 'polaroid'
       | 'email-verification-code'
+      | 'event'
       | 'exports'
       | 'imports';
     drafts?: ('yes' | 'no') | null;

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -383,13 +383,9 @@ export interface Event {
    */
   description?: string | null;
   /**
-   * Date that the event is being run
+   * Date and time that the event is being run
    */
   date: string;
-  /**
-   * Time that the event is being run
-   */
-  time: string;
   /**
    * The image posted to socials for this event and to be shown on the site
    */
@@ -802,7 +798,6 @@ export interface EventSelect<T extends boolean = true> {
   name?: T;
   description?: T;
   date?: T;
-  time?: T;
   design?: T;
   signUpForm?: T;
   updatedAt?: T;


### PR DESCRIPTION
# Description

This PR adds the Event collection to Payload CMS for managing site events.

- adds new `Event` collection to Payload CMS with fields for `name`, `description`, `date`, `design` (media relationship), and `signUpForm` link
- creates new route `/events` and slug `event` for the Event collection
- integrates collection with Payload's draft/publish system and revalidation hooks that trigger on create/update/delete
- combines date and time into a single field with day-and-time picker UI for better UX
- renames `signUpForm` field to use camelCase naming convention for consistency with other fields

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
