### PR TITLE
feat(auth): redirect to profile after sign-up and login with session propagation

### DIFF
--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -13,9 +13,9 @@ export async function POST(request: Request) {
 
     if (body?.existingMember === true) {
       const user = createUserServerSchema.parse(body)
-      const baUser = await authService.signUpBetterAuth(user)
+      const { user: baUser, headers } = await authService.signUpBetterAuth(user)
       const member = await authService.linkExistingMember(user.email, baUser.id)
-      return new Response(JSON.stringify(member), { status: 201 })
+      return new Response(JSON.stringify(member), { status: 201, headers })
     }
 
     const { password, ...memberData } = signUpSchema.parse(body)
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
       limit: 1,
     })
 
-    const baUser = await authService.signUpBetterAuth({
+    const { user: baUser, headers } = await authService.signUpBetterAuth({
       firstName: memberData.firstName,
       lastName: memberData.lastName,
       email: memberData.email,
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
         ? await authService.linkExistingMember(memberData.email, baUser.id)
         : await authService.signUpPayloadMember(memberData, baUser.id)
 
-    return new Response(JSON.stringify(member), { status: 201 })
+    return new Response(JSON.stringify(member), { status: 201, headers })
   } catch (err) {
     if (err instanceof SyntaxError) {
       return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 })

--- a/src/components/Composite/LoginForm/LoginForm.tsx
+++ b/src/components/Composite/LoginForm/LoginForm.tsx
@@ -54,7 +54,7 @@ export const LoginForm = () => {
         return
       }
 
-      void refetchSession()
+      await refetchSession()
       router.push(Routes.PROFILE)
       toast.success({
         description: "Successfully logged in!",

--- a/src/components/Composite/LoginForm/LoginForm.tsx
+++ b/src/components/Composite/LoginForm/LoginForm.tsx
@@ -22,9 +22,9 @@ export const LoginForm = () => {
   })
   const [loading, setLoading] = useState(false)
   const router = useRouter()
+  const { refetch: refetchSession } = authClient.useSession()
 
   const onSubmit = async (data: LoginOutput) => {
-    router.prefetch(Routes.HOME)
     setLoading(true)
     try {
       const { error } = await authClient.signIn.email({
@@ -45,7 +45,17 @@ export const LoginForm = () => {
         return
       }
 
-      router.push(Routes.HOME)
+      const { data: session, error: sessionError } = await authClient.getSession()
+      if (!session || sessionError) {
+        console.error("Session confirmation failed after log in", sessionError)
+        toast.error({
+          description: "Logged in, but we couldn't confirm your session. Please try again.",
+        })
+        return
+      }
+
+      void refetchSession()
+      router.push(Routes.PROFILE)
       toast.success({
         description: "Successfully logged in!",
       })

--- a/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
+++ b/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
@@ -143,7 +143,7 @@ export const EmailVerificationStep = () => {
           return
         }
 
-        void refetchSession()
+        await refetchSession()
         router.push(Routes.PROFILE)
         toast.success({
           description: "Successfully signed up!\nWe look forward to seeing you at our events!!",

--- a/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
+++ b/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
@@ -132,8 +132,18 @@ export const EmailVerificationStep = () => {
           return
         }
 
-        await refetchSession() // bypasses authClient's signUp methods (raw fetch to our route), so manually refresh the session store before navigating
         reset()
+        const { data: session, error } = await authClient.getSession()
+        if (!session || error) {
+          console.error("Session confirmation failed after sign-up", error)
+          toast.error({
+            description: "Signed up, but we couldn't confirm your session. Please log in.",
+          })
+          router.push(Routes.LOGIN)
+          return
+        }
+
+        void refetchSession()
         router.push(Routes.PROFILE)
         toast.success({
           description: "Successfully signed up!\nWe look forward to seeing you at our events!!",

--- a/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
+++ b/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { Button } from "@/components/Primitive"
 import { PinInput } from "@/components/Primitive/PinInput/PinInput"
+import { authClient } from "@/lib/auth-client"
 import { ApiRoutes, Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import {
@@ -22,6 +23,7 @@ export const EmailVerificationStep = () => {
   const [resendCooldown, setResendCooldown] = useState(RESEND_COOLDOWN_S)
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const router = useRouter()
+  const { refetch: refetchSession } = authClient.useSession()
 
   const {
     control,
@@ -112,7 +114,6 @@ export const EmailVerificationStep = () => {
       const { memberExists } = await verifyResponse.json()
 
       if (memberExists) {
-        router.prefetch(Routes.LOGIN)
         const signUpResponse = await fetch(ApiRoutes.SIGN_UP.ROOT, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -131,8 +132,9 @@ export const EmailVerificationStep = () => {
           return
         }
 
+        await refetchSession() // bypasses authClient's signUp methods (raw fetch to our route), so manually refresh the session store before navigating
         reset()
-        router.push(Routes.LOGIN)
+        router.push(Routes.PROFILE)
         toast.success({
           description: "Successfully signed up!\nWe look forward to seeing you at our events!!",
         })

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -88,8 +88,18 @@ export const MemberStep = () => {
         }
         return
       }
-      await refetchSession() // bypassed authClient's signUp methods (raw fetch to our route), so manually refresh the session store before navigating
       reset()
+      const { data: session, error } = await authClient.getSession()
+      if (!session || error) {
+        console.error("Session confirmation failed after sign-up", error)
+        toast.error({
+          description: "Signed up, but we couldn't confirm your session. Please log in.",
+        })
+        router.push(Routes.LOGIN)
+        return
+      }
+
+      void refetchSession()
       router.push(Routes.PROFILE)
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -11,6 +11,7 @@ import { Button, Radio } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
 import { MultiSelect } from "@/components/Primitive/MultiSelect/MultiSelect"
 import { Select } from "@/components/Primitive/Select/Select"
+import { authClient } from "@/lib/auth-client"
 import { ApiRoutes, Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import { memberSchema } from "@/types/schemas/member"
@@ -42,6 +43,7 @@ export const MemberStep = () => {
   const { step1, step2, setStep2, prevStep, reset } = useSignUpFormStore()
   const [loading, setLoading] = useState(false)
   const router = useRouter()
+  const { refetch: refetchSession } = authClient.useSession()
 
   const {
     control,
@@ -68,7 +70,6 @@ export const MemberStep = () => {
       return
     }
     setStep2(step2Data)
-    router.prefetch(Routes.HOME)
     setLoading(true)
     try {
       const response = await fetch(ApiRoutes.SIGN_UP.ROOT, {
@@ -87,8 +88,9 @@ export const MemberStep = () => {
         }
         return
       }
+      await refetchSession() // bypassed authClient's signUp methods (raw fetch to our route), so manually refresh the session store before navigating
       reset()
-      router.push(Routes.LOGIN)
+      router.push(Routes.PROFILE)
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",
       })

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -99,7 +99,7 @@ export const MemberStep = () => {
         return
       }
 
-      void refetchSession()
+      await refetchSession()
       router.push(Routes.PROFILE)
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext } from "react"
+import { createContext, type ReactNode, useContext, useRef } from "react"
 import { authClient } from "@/lib/auth-client"
 
 export type Session = typeof authClient.$Infer.Session | null
@@ -19,7 +19,10 @@ export const SessionProvider = ({
   initialSession?: Session
 }) => {
   const { data: clientSession, isPending } = authClient.useSession()
-  const session = isPending ? initialSession : (clientSession ?? null)
+  const hasResolvedOnce = useRef(false)
+  if (!isPending) hasResolvedOnce.current = true
+
+  const session = isPending && !hasResolvedOnce.current ? initialSession : (clientSession ?? null)
 
   return <SessionContext.Provider value={session}>{children}</SessionContext.Provider>
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -57,16 +57,17 @@ export class AuthService {
     }
   }
 
-  public async signUpBetterAuth(data: CreateUserInput): Promise<User> {
+  public async signUpBetterAuth(data: CreateUserInput): Promise<{ user: User; headers: Headers }> {
     try {
-      const result = await auth.api.signUpEmail({
+      const { response, headers } = await auth.api.signUpEmail({
         body: {
           name: `${data.firstName} ${data.lastName}`,
           email: data.email,
           password: data.password,
         },
+        returnHeaders: true,
       })
-      return result.user
+      return { user: response.user, headers }
     } catch (err) {
       if (isAPIError(err) && err.body?.code === "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL") {
         throw new DuplicateFieldError("email")


### PR DESCRIPTION
# Description

This PR improves the sign-up and login flows by redirecting to the profile page after authentication, with proper session propagation and confirmation.

- redirects both sign-up and login flows to `Routes.PROFILE` instead of intermediate pages
- propagates the session cookie from the API response by capturing and forwarding headers
- confirms the session exists before redirecting to prevent silent authentication failures
- refetches the session context after authentication to ensure client state is in sync
- fixes `SessionContext` to not mask a resolved client session behind stale `initialSession`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
