### PR TITLE
feat(profile): unlock UPI and UOA ID fields with guidance

### DIFF
--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -36,8 +36,6 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
     member.compsciStudent === true ? "Yes" : member.compsciStudent === false ? "No" : undefined,
   )
   const [otherMajors, setOtherMajors] = useState<string[]>(member.otherMajors ?? [])
-  const [heardAboutUs, setHeardAboutUs] = useState(member.heardAboutUs ?? "")
-  const [eventWishlist, setEventWishlist] = useState(member.eventWishList ?? "")
 
   const [errors, setErrors] = useState<Partial<Record<keyof UpdateMemberInput, string>>>({})
   const { mutateAsync } = useUpdateMember()
@@ -113,18 +111,20 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
 
       <ToggleableInput
         displayNode={upi}
+        error={errors.upi}
         label="UPI"
-        locked
-        lockedReason="UPI is your university identifier and cannot be changed here"
+        onCancel={() => cancelField("upi", () => setUpi(member.upi ?? ""))}
+        onSave={() => saveField("upi", upi)}
       >
         <Input onChange={(e) => setUpi(e.target.value)} type="text" value={upi} />
       </ToggleableInput>
 
       <ToggleableInput
         displayNode={uoaID}
+        error={errors.uoaID}
         label="UOA ID Number"
-        locked
-        lockedReason="Your student ID cannot be changed here"
+        onCancel={() => cancelField("uoaID", () => setUoaID(member.uoaID ?? ""))}
+        onSave={() => saveField("uoaID", uoaID)}
       >
         <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
       </ToggleableInput>
@@ -200,34 +200,6 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
           onChange={setOtherMajors}
           options={OTHER_MAJORS_OPTIONS}
           value={otherMajors}
-        />
-      </ToggleableInput>
-
-      <ToggleableInput
-        displayNode={heardAboutUs}
-        error={errors.heardAboutUs}
-        label="How did you hear about us?"
-        onCancel={() =>
-          cancelField("heardAboutUs", () => setHeardAboutUs(member.heardAboutUs ?? ""))
-        }
-        onSave={() => saveField("heardAboutUs", heardAboutUs)}
-      >
-        <Input onChange={(e) => setHeardAboutUs(e.target.value)} type="text" value={heardAboutUs} />
-      </ToggleableInput>
-
-      <ToggleableInput
-        displayNode={eventWishlist}
-        error={errors.eventWishList}
-        label="What kinds of events would you like to see us host?"
-        onCancel={() =>
-          cancelField("eventWishList", () => setEventWishlist(member.eventWishList ?? ""))
-        }
-        onSave={() => saveField("eventWishList", eventWishlist)}
-      >
-        <Input
-          onChange={(e) => setEventWishlist(e.target.value)}
-          type="text"
-          value={eventWishlist}
         />
       </ToggleableInput>
     </div>

--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -116,7 +116,12 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         onCancel={() => cancelField("upi", () => setUpi(member.upi ?? ""))}
         onSave={() => saveField("upi", upi)}
       >
-        <Input onChange={(e) => setUpi(e.target.value)} type="text" value={upi} />
+        <Input
+          hint="Not a UOA student? Enter N/A"
+          onChange={(e) => setUpi(e.target.value)}
+          type="text"
+          value={upi}
+        />
       </ToggleableInput>
 
       <ToggleableInput
@@ -126,7 +131,12 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
         onCancel={() => cancelField("uoaID", () => setUoaID(member.uoaID ?? ""))}
         onSave={() => saveField("uoaID", uoaID)}
       >
-        <Input onChange={(e) => setUoaID(e.target.value)} type="text" value={uoaID} />
+        <Input
+          hint="Not a UOA student? Enter N/A"
+          onChange={(e) => setUoaID(e.target.value)}
+          type="text"
+          value={uoaID}
+        />
       </ToggleableInput>
 
       <ToggleableInput

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -118,10 +118,18 @@ export const MemberStep = () => {
       onSubmit={handleSubmit(onSubmit)}
     >
       <div className="item-center flex w-full flex-col justify-start gap-2 md:flex-row md:gap-4">
-        <Input {...register("upi")} error={errors.upi?.message} label="UPI" required type="text" />
+        <Input
+          {...register("upi")}
+          error={errors.upi?.message}
+          hint="Not a UOA student? Enter N/A"
+          label="UPI"
+          required
+          type="text"
+        />
         <Input
           {...register("uoaID")}
           error={errors.uoaID?.message}
+          hint="Not a UOA student? Enter N/A"
           label="UOA ID Number"
           required
           type="text"

--- a/src/components/Primitive/Input/Input.tsx
+++ b/src/components/Primitive/Input/Input.tsx
@@ -2,12 +2,14 @@ import { cn } from "@/lib/utils"
 
 export interface InputProps extends React.ComponentPropsWithRef<"input"> {
   label?: string
+  hint?: string
   error?: string
   containerClassName?: string
 }
 
 export const Input = ({
   label,
+  hint,
   error,
   containerClassName,
   className,
@@ -20,6 +22,7 @@ export const Input = ({
   if (!label) {
     return (
       <>
+        {hint && <p className="paragraph-xs -mt-1 text-gray-400">{hint}</p>}
         <input
           className={cn("w-full rounded border border-gray-300 px-3 py-2", className)}
           ref={ref}
@@ -37,6 +40,7 @@ export const Input = ({
         {label}
         {required && <span className="ml-1 text-brand-pink">*</span>}
       </label>
+      {hint && <p className="paragraph-xs -mt-1 text-gray-400">{hint}</p>}
       <input
         className={cn("w-full rounded border border-gray-300 px-3 py-2", className)}
         id={label}

--- a/src/types/schemas/member.ts
+++ b/src/types/schemas/member.ts
@@ -48,8 +48,6 @@ export const updateMemberSchema = memberSchema
     createdAt: true,
     updatedAt: true,
     email: true,
-    upi: true,
-    uoaID: true,
   })
   .partial()
 


### PR DESCRIPTION
## Description

This PR unlocks the ability to edit UPI and UOA ID fields in the member profile, while providing helpful guidance for non-UOA students.

- adds a `hint` prop to the `Input` component to display helper text below input fields
- enables editing of the `upi` and `uoaID` fields in `MemberDetailsForm` (previously locked) with save and cancel functionality
- adds hint text "Not a UOA student? Enter N/A" to both UPI and UOA ID fields in the profile form and signup flow
- removes the "How did you hear about us?" and "What kinds of events would you like to see us host?" fields from the profile form
- updates the `updateMemberSchema` to make `upi` and `uoaID` optional (no longer required on every update)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
