### PR TITLE
fix(next): deduplicate images config rules

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,13 +4,6 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "standalone",
-  images: {
-    localPatterns: [
-      {
-        pathname: "/payload/api/media/file/**",
-      },
-    ],
-  },
   turbopack: {
     resolveExtensions: [".mdx", ".tsx", ".ts", ".jsx", ".js", ".mjs", ".json"],
     rules: {


### PR DESCRIPTION
## Description

This PR removes the duplicate `images` configuration from `next.config.ts` that was conflicting with other Next.js settings.

- removes the redundant `images` object with `localPatterns` configuration that was duplicating existing settings

Not related to a ticket.

## How to test this change

Verify that the Next.js application builds and starts correctly:

```bash
pnpm build
pnpm dev
```

The app should build without warnings or errors related to Next.js configuration. The removed configuration was redundant and should not affect image handling or any runtime behavior.