### PR TITLE
fix(pin-input): ensure that pin input responds to android keyboard events

### DIFF
--- a/src/components/Primitive/PinInput/PinInput.tsx
+++ b/src/components/Primitive/PinInput/PinInput.tsx
@@ -31,26 +31,24 @@ export const PinInput = ({
   const [slots, setSlots] = useState<string[]>(() =>
     value.split("").concat(Array(length).fill("")).slice(0, length),
   )
+  const slotsRef = useRef(slots)
 
   useEffect(() => {
     if (value === "") {
-      setSlots(Array(length).fill(""))
+      const cleared = Array(length).fill("")
+      slotsRef.current = cleared
+      setSlots(cleared)
     }
   }, [value, length])
 
   const commit = (next: string[]) => {
+    slotsRef.current = next
     setSlots(next)
     onChange(next.join(""))
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, i: number) => {
-    if (e.key >= "0" && e.key <= "9") {
-      e.preventDefault()
-      const next = [...slots]
-      next[i] = e.key
-      commit(next)
-      if (i < length - 1) inputRefs.current[i + 1]?.focus()
-    } else if (e.key === "Backspace") {
+    if (e.key === "Backspace") {
       e.preventDefault()
       const next = [...slots]
       if (next[i]) {
@@ -67,11 +65,41 @@ export const PinInput = ({
     } else if (e.key === "ArrowRight") {
       e.preventDefault()
       if (i < length - 1) inputRefs.current[i + 1]?.focus()
-    } else if (e.key === "Enter" || e.key === "Tab" || e.ctrlKey || e.metaKey) {
-      // let native form submit / focus behavior through
-    } else {
-      e.preventDefault()
     }
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>, i: number) => {
+    const raw = e.target.value
+
+    if (raw === "") {
+      if (slotsRef.current[i]) {
+        const next = [...slotsRef.current]
+        next[i] = ""
+        commit(next)
+      }
+      return
+    }
+
+    const digits = raw.replace(/\D/g, "")
+
+    if (digits.length === 0) {
+      commit([...slotsRef.current])
+      return
+    }
+
+    if (digits.length > 1) {
+      // Multi-char value in a single slot (autofill/dictation) - replace the whole code from slot 0, same as handlePaste
+      const clipped = digits.slice(0, length)
+      const next = clipped.split("").concat(Array(length).fill("")).slice(0, length)
+      commit(next)
+      inputRefs.current[Math.min(clipped.length, length - 1)]?.focus()
+      return
+    }
+
+    const next = [...slotsRef.current]
+    next[i] = digits
+    commit(next)
+    if (i < length - 1) inputRefs.current[i + 1]?.focus()
   }
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
@@ -108,7 +136,7 @@ export const PinInput = ({
             inputMode="numeric"
             key={SLOT_KEYS[i]}
             maxLength={1}
-            onChange={() => {}}
+            onChange={(e) => handleChange(e, i)}
             onFocus={(e) => e.target.select()}
             onKeyDown={(e) => handleKeyDown(e, i)}
             onPaste={handlePaste}

--- a/src/components/Primitive/PinInput/PinInput.tsx
+++ b/src/components/Primitive/PinInput/PinInput.tsx
@@ -48,7 +48,13 @@ export const PinInput = ({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, i: number) => {
-    if (e.key === "Backspace") {
+    if (e.key >= "0" && e.key <= "9") {
+      e.preventDefault()
+      const next = [...slots]
+      next[i] = e.key
+      commit(next)
+      if (i < length - 1) inputRefs.current[i + 1]?.focus()
+    } else if (e.key === "Backspace") {
       e.preventDefault()
       const next = [...slots]
       if (next[i]) {
@@ -65,6 +71,11 @@ export const PinInput = ({
     } else if (e.key === "ArrowRight") {
       e.preventDefault()
       if (i < length - 1) inputRefs.current[i + 1]?.focus()
+    } else if (e.key.length === 1 && !(e.key >= "0" && e.key <= "9")) {
+      // Only block real single-char non-digit keys (letters/symbols). Multi-char
+      // key reports (Enter, Tab, and IME-composed "Unidentified"/"Process" from
+      // some Android keyboards) fall through to native input / handleChange.
+      e.preventDefault()
     }
   }
 


### PR DESCRIPTION
# Description

This PR adds a dedicated `onChange` handler to `PinInput` so it correctly handles input that arrives outside a normal keypress (i.e. browser autofill, voice dictation, or a paste landing in a single slot) and android devices that dont emit an `onKeyDown` event work.

- adds `slotsRef` alongside `slots` state so handlers always read the latest slot values, avoiding stale closures when multiple characters arrive in quick succession
- introduces `handleChange`, which:
  - commits a single digit and advances focus to the next slot
  - detects multi-character values (i.e. autofill or dictation filling more than one slot at once) and distributes them across slots the same way `handlePaste` does
  - normalizes input to digits only, discarding anything non-numeric
- wires the input's `onChange` prop to `handleChange` (previously a no-op)
- keeps digit handling in `handleKeyDown` alongside `handleChange`, since some browsers/devices fire `onKeyDown` for digit keys without a matching change event

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
