### PR TITLE
feat(team-page): group members by team

### DIFF
--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -32,6 +32,21 @@ const TEAM_ORDER = [
 ]
 
 /**
+ * Ranks an exec by their primary (first-listed) team, for grouping purposes
+ */
+const primaryTeamRank = (exec: Executive): number => {
+  const primaryTeam = exec.role?.teams?.[0]
+  if (!primaryTeam) return TEAM_ORDER.length
+  return TEAM_ORDER.indexOf(primaryTeam as ExecutiveTeam)
+}
+
+/**
+ * Ranks an exec by their level (e.g. director vs executive), for grouping purposes
+ */
+const levelRank = (exec: Executive): number =>
+  EXECUTIVE_LEVEL_ORDER.indexOf((exec.role?.level ?? ExecutiveLevel.EXECUTIVE) as ExecutiveLevel)
+
+/**
  * A client component that displays the team page with current and past executives
  *
  * @param execs a payload response containing exec documents
@@ -40,15 +55,11 @@ const TEAM_ORDER = [
 export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
   const currentExecs = execs?.docs
     .filter((exec: Executive) => exec.isCurrent)
-    .sort(
-      (a, b) =>
-        EXECUTIVE_LEVEL_ORDER.indexOf(
-          (a.role?.level ?? ExecutiveLevel.EXECUTIVE) as ExecutiveLevel,
-        ) -
-        EXECUTIVE_LEVEL_ORDER.indexOf(
-          (b.role?.level ?? ExecutiveLevel.EXECUTIVE) as ExecutiveLevel,
-        ),
-    )
+    .sort((a, b) => {
+      const levelDiff = levelRank(a) - levelRank(b)
+      if (levelDiff !== 0) return levelDiff
+      return primaryTeamRank(a) - primaryTeamRank(b)
+    })
   const pastExecs = execs?.docs
     .filter((exec: Executive) => !exec.isCurrent)
     .sort(

--- a/src/app/(frontend)/team/_components/TeamPageClient.tsx
+++ b/src/app/(frontend)/team/_components/TeamPageClient.tsx
@@ -126,7 +126,7 @@ export const TeamPageClient = ({ execs }: { execs: { docs: Executive[] } }) => {
         </div>
       </Section>
       <Section subtitle="UOACS Alumni" title="Past Executives" titleProps={{ h: 1, period: true }}>
-        <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-[4.5rem]">
+        <div className="grid w-full grid-cols-1 justify-center gap-12 md:grid-cols-[repeat(auto-fill,22.5rem)] md:gap-x-16 md:gap-y-18">
           {pastTeams.map((team: string) => {
             const execsInTeam = pastExecs.filter((exec: Executive) =>
               (exec.role?.teams ?? []).includes(toTeam(team)),


### PR DESCRIPTION
# Description
The current team page on the UOACS website displays the team by level correctly, but looks unorganised as execs are displayed in no particular order/sorting. This PR organises team members by grouping them by team (using the first value in the team array), while maintaining the hierachy ordering.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

**Before:**
<img width="1347" height="957" alt="image" src="https://github.com/user-attachments/assets/1bbf8492-9ff6-45a0-a521-4a6308c804f9" />

**After:**
<img width="1328" height="958" alt="image" src="https://github.com/user-attachments/assets/5ca45f75-dc8c-45b7-b33e-6aebbcf5fc43" />


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member
