### PR TITLE
fix(docker): drop unused NODE_VERSION arg indirection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1.23
-ARG NODE_VERSION=24.12.0
-FROM node:${NODE_VERSION}-alpine AS base
+FROM node:24.14.0-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
## Description

This PR fixes Renovate's inability to update the Node.js version in the `Dockerfile` by eliminating an unreliable indirection pattern.

**Root cause:** The `Dockerfile` was using `ARG NODE_VERSION=24.12.0` + `FROM node:${NODE_VERSION}-alpine`, but Renovate's stale `renovate/node.js` branch held a replace plan targeting the old literal `node:24.12.0-alpine` string, which no longer existed after the refactor. This caused the error "Cannot find replaceString in current file content".

**Changes:**
- removes the unused `ARG NODE_VERSION` variable
- hardcodes `FROM node:24.14.0-alpine AS base` directly, matching `.nvmrc`
- fixes version drift that had accumulated (.nvmrc was at 24.14.0 while the Dockerfile ARG was at 24.12.0)

A plain `FROM image:tag` line is the most reliably-parsed pattern for Renovate's dockerfile manager, so future Renovate PRs for Node version bumps should apply cleanly.

Not related to a ticket

### How to test this change

1. Verify the Dockerfile builds successfully:
   ```bash
   docker build . -t uoacs-test
   ```

2. Check that the Node version in the base image is 24.14.0:
   ```bash
   docker run --rm uoacs-test node --version
   ```

3. After this PR merges, delete or close the stale `renovate/node.js` branch so Renovate re-scans with a fresh branch instead of reusing its stale cached diff.