### PR TITLE
fix(auth): rethrow Next internal errors from getSession

### DIFF
--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,4 +1,5 @@
 import { headers } from "next/headers"
+import { unstable_rethrow } from "next/navigation"
 import { cache } from "react"
 import { auth } from "@/lib/auth"
 
@@ -6,6 +7,7 @@ export const getSession = cache(async () => {
   try {
     return await auth.api.getSession({ headers: await headers() })
   } catch (err) {
+    unstable_rethrow(err)
     console.error("[getSession] auth.api.getSession threw unexpectedly", { error: err })
     return null
   }


### PR DESCRIPTION
## Description

This PR fixes the build-time console.error noise from `getSession()` when Next.js static-generation prepass encounters the expected `DYNAMIC_SERVER_USAGE` error.

- adds `import { unstable_rethrow } from "next/navigation"` to rethrow Next's internal control-flow errors before logging
- rethrows digested internal errors before the console.error call, allowing genuine auth failures to be logged as before
- eliminates spurious "[getSession] auth.api.getSession threw unexpectedly" log entries during `pnpm build` on static routes

Not related to a ticket.

## How to test this change

Run `pnpm build` and verify the following:
- Build output is clean with no `[getSession]` errors printed to stdout
- Static routes (/, /login, /privacy, /profile, /sign-up, /sponsors, /team) show `ƒ` in the route summary, indicating they're correctly marked as dynamic

Before this fix, `pnpm build` would log an error block for each static route that triggered the prepass. After the fix, the build completes silently.