### PR TITLE
fix(navbar): stop mobile menu from trapping page scroll

### DIFF
--- a/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/Composite/Navbar/MobileNavbar/MobileNavbar.tsx
@@ -48,14 +48,14 @@ export const MobileNavbar = ({ links, socialLinks }: NavbarProps) => {
   }, [])
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden"
-    } else {
-      document.body.style.overflow = ""
-    }
+    if (!isOpen) return
+
+    document.documentElement.classList.add("overflow-hidden", "touch-none")
+    document.body.classList.add("overflow-hidden", "touch-none")
 
     return () => {
-      document.body.style.overflow = ""
+      document.documentElement.classList.remove("overflow-hidden", "touch-none")
+      document.body.classList.remove("overflow-hidden", "touch-none")
     }
   }, [isOpen])
 

--- a/src/components/Composite/Navbar/MobileNavbar/variants.ts
+++ b/src/components/Composite/Navbar/MobileNavbar/variants.ts
@@ -4,7 +4,7 @@ import { tv, type VariantProps } from "tailwind-variants"
  * Variants for the MobileNavbar component.
  */
 export const mobileNavbarVariants = tv({
-  base: "md:hidden fixed flex left-0 top-0 z-50 h-full w-full gap-16 flex-col items-center justify-start bg-white overscroll-y-hidden pt-6",
+  base: "md:hidden fixed flex left-0 top-0 z-50 h-dvh w-full gap-16 flex-col items-center justify-start bg-white overscroll-y-hidden touch-pan-y pt-6",
   variants: {
     isOpen: {
       true: "flex",


### PR DESCRIPTION
### Description

This PR fixes the mobile hamburger menu from trapping the user's scroll gesture on iOS Safari. Previously, the scroll-lock only set `overflow: hidden` on `document.body`, which doesn't block iOS Safari's WebKit-level touch-driven rubber-band/bounce scrolling, leaving a residual scrollable area that persisted after the menu closed.

- replaces inline style approach with Tailwind class toggling on both `document.documentElement` and `document.body`
- adds `touch-none` class (sets `touch-action: none`) to block touch gestures at the input level instead of relying on `overflow`
- updates panel height from `h-full` to `h-dvh` to track the actual visible viewport as mobile browser chrome collapses/expands
- adds `touch-pan-y` class to the panel so its internal content can still be vertically scrolled (since `touch-action: none` on ancestors would otherwise cascade to descendants)

This became an issue because adding the events page to the navbar caused it to become too large and these issues came into effect.

### How to test this change

I would recommend testing on 
```
const navbarLinks: { label: string; href: string }[] = [
  { label: "Home", href: Routes.HOME },
  { label: "Meet The Team", href: Routes.TEAM },
  { label: "Our Sponsors", href: Routes.SPONSORS },
  { label: "Events", href: Routes.EVENTS }
]
```
or some extended list of links

On iOS Safari (or Chrome on iOS):
1. Open the site on a mobile device in portrait orientation
2. Tap the hamburger menu icon to open the mobile navbar
3. Attempt to scroll the page content behind the menu — nothing should move, and your scroll gesture should not be trapped or feel sticky
4. Close the menu by tapping the X or clicking outside
5. Verify the page scrolls normally again without any lingering scroll-lock behavior
6. Test scrolling within the menu panel itself — the internal content should scroll smoothly while the page remains locked

I would recommend testing both with the menu open and closed to ensure the cleanup in the effect runs correctly.