### PR TITLE
feat(components): add EncryptedBanner component with media query and container width tracking

### DIFF
--- a/src/components/Generic/EncryptedBanner/EncryptedBanner.stories.tsx
+++ b/src/components/Generic/EncryptedBanner/EncryptedBanner.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+import { EncryptedBanner, type EncryptedBannerProps } from "./EncryptedBanner"
+
+const meta: Meta<EncryptedBannerProps> = {
+  title: "Generic Components/EncryptedBanner",
+  component: EncryptedBanner,
+  args: { layers: 1 },
+  argTypes: {
+    layers: { control: { type: "select" }, options: [1, 2] },
+    length: { control: { type: "number" } },
+    colour: { control: { type: "select" }, options: ["pink", "orange", "purple", "blue"] },
+    secondaryColour: { control: { type: "select" }, options: ["pink", "orange", "purple", "blue"] },
+  },
+}
+
+export default meta
+type Story = StoryObj<EncryptedBannerProps>
+
+export const SingleLayer: Story = {}
+
+export const DoubleLayer: Story = {
+  args: { layers: 2 },
+}

--- a/src/components/Generic/EncryptedBanner/EncryptedBanner.tsx
+++ b/src/components/Generic/EncryptedBanner/EncryptedBanner.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useRef } from "react"
+import { useContainerWidth } from "@/hooks/useContainerWidth"
+import { useMediaQuery } from "@/hooks/useMediaQuery"
+import { cn } from "@/lib/utils"
+import { EncryptedBannerLayer } from "./EncryptedBannerLayer"
+import type { EncryptedBannerLayerVariants } from "./variants"
+
+/** Tailwind's `md` breakpoint, matching the text-xs -> md:text-base switch in variants.ts */
+const MD_BREAKPOINT_QUERY = "(min-width: 768px)"
+
+/**
+ * Approximate rendered width (px) of one monospace character, at each font
+ * size the banner uses (text-xs below `md`, text-base from `md` up)
+ */
+const CHAR_WIDTH_PX = { mobile: 6.4, desktop: 8.5 } as const
+
+/**
+ * Props for the EncryptedBanner component
+ */
+export interface EncryptedBannerProps {
+  /**
+   * Number of scrambled character bands to overlay
+   */
+  layers?: 1 | 2
+  /**
+   * Number of characters to render per band. Defaults to however many are
+   * needed to fill the container's width, so the full wave/arc is visible
+   * edge-to-edge instead of overflowing and being cropped.
+   */
+  length?: number
+  /**
+   * Colour of the primary band
+   */
+  colour?: EncryptedBannerLayerVariants["colour"]
+  /**
+   * Colour of the secondary band, when `layers` is 2
+   */
+  secondaryColour?: EncryptedBannerLayerVariants["colour"]
+  /**
+   * Additional class names to apply to the wrapping container
+   */
+  className?: string
+}
+
+/**
+ * A decorative banner that displays a static "wavy" strip of random
+ * nonalphanumeric characters, with an optional second overlayed band.
+ *
+ * @param layers number of scrambled character bands to overlay (1 or 2)
+ * @param length number of characters to render per band (auto-fit to width if omitted)
+ * @param colour colour of the primary band
+ * @param secondaryColour colour of the secondary band, when `layers` is 2
+ * @param className additional class names to apply to the container
+ * @returns an encrypted-style banner component
+ */
+export const EncryptedBanner = ({
+  layers = 1,
+  length,
+  colour = "blue",
+  secondaryColour = "pink",
+  className,
+}: EncryptedBannerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const containerWidth = useContainerWidth(containerRef)
+  const isMdUp = useMediaQuery(MD_BREAKPOINT_QUERY)
+  const charWidthPx = isMdUp ? CHAR_WIDTH_PX.desktop : CHAR_WIDTH_PX.mobile
+  const computedLength = length ?? Math.max(40, Math.ceil(containerWidth / charWidthPx))
+
+  return (
+    <div
+      className={cn("relative h-32 w-full overflow-hidden md:h-48", className)}
+      ref={containerRef}
+    >
+      <div className="absolute inset-0 flex -rotate-2 items-center">
+        <EncryptedBannerLayer
+          colour={colour}
+          length={computedLength}
+          sweep={{ startOffset: 0, intervalMs: 30, count: 3 }}
+          wave={{ amplitude: 42, maxRotate: 12, steepness: 5 }}
+        />
+      </div>
+      {layers === 2 && (
+        <div className="absolute inset-0 flex -rotate-3 items-center">
+          <EncryptedBannerLayer
+            colour={secondaryColour}
+            length={computedLength}
+            sweep={{ startOffset: 0.5, intervalMs: 45, count: 2 }}
+            wave={{ amplitude: 34, flip: true, maxRotate: 9, steepness: 4 }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Generic/EncryptedBanner/EncryptedBannerLayer.tsx
+++ b/src/components/Generic/EncryptedBanner/EncryptedBannerLayer.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { type EncryptedTextSweepOptions, useEncryptedText } from "./useEncryptedText"
+import { type EncryptedBannerLayerVariants, encryptedBannerLayerVariants } from "./variants"
+
+export interface WaveConfig {
+  /** Vertical swing of the S-curve, in pixels */
+  amplitude: number
+  /** How sharply the curve transitions through its midpoint (higher = steeper) */
+  steepness: number
+  /** Per-character rotation at the curve's steepest point, in degrees */
+  maxRotate: number
+  /** Mirror the curve across the x-axis */
+  flip?: boolean
+}
+
+const getCharacterStyle = (
+  index: number,
+  length: number,
+  { amplitude, steepness, maxRotate, flip }: WaveConfig,
+) => {
+  const progress = index / (length - 1)
+  const sign = flip ? -1 : 1
+  const t = Math.tanh(steepness * (progress - 0.5))
+  const y = sign * amplitude * t
+  const rotate = sign * maxRotate * (1 - t * t)
+
+  return { transform: `translateY(${y}px) rotate(${rotate}deg)` }
+}
+
+export interface EncryptedBannerLayerProps {
+  length: number
+  colour: EncryptedBannerLayerVariants["colour"]
+  wave: WaveConfig
+  sweep?: EncryptedTextSweepOptions
+  className?: string
+}
+
+export const EncryptedBannerLayer = ({
+  length,
+  colour,
+  wave,
+  sweep,
+  className,
+}: EncryptedBannerLayerProps) => {
+  const text = useEncryptedText(length, sweep)
+
+  return (
+    <span className={cn(encryptedBannerLayerVariants({ colour }), className)}>
+      {text.split("").map((char, index) => (
+        <span
+          className="inline-block"
+          // biome-ignore lint/suspicious/noArrayIndexKey: characters are positioned by index along the wave, so index is the stable identity
+          key={index}
+          style={getCharacterStyle(index, length, wave)}
+        >
+          {char}
+        </span>
+      ))}
+    </span>
+  )
+}

--- a/src/components/Generic/EncryptedBanner/useEncryptedText.ts
+++ b/src/components/Generic/EncryptedBanner/useEncryptedText.ts
@@ -1,0 +1,82 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+const CHARSET = "!@#$%^&*()_+-=[]{}|;:,.<>/?~`\\"
+
+const randomChar = () => CHARSET[Math.floor(Math.random() * CHARSET.length)]
+
+const randomString = (length: number) => Array.from({ length }, randomChar).join("")
+
+/** How often the sweeping strip advances to the next position, in ms */
+const SWEEP_INTERVAL_MS = 30
+
+/** Strip width oscillates between these bounds, in characters */
+const MIN_STRIP_WIDTH = 5
+const MAX_STRIP_WIDTH = 20
+
+/** How many sweep steps make up one full width oscillation */
+const WIDTH_CYCLE_STEPS = 40
+
+export interface EncryptedTextSweepOptions {
+  /** Where the first strip begins, as a fraction of `length` (0-1) */
+  startOffset?: number
+  /** How often each strip advances to the next position, in ms */
+  intervalMs?: number
+  /** Number of independent strips sweeping concurrently, evenly spaced along the text */
+  count?: number
+}
+
+/**
+ * Generates a string of random nonalphanumeric characters. After mount,
+ * `count` independent strips sweep across the text from evenly spaced
+ * starting points, each shifting and re-randomizing one position at a time
+ * before restarting from the beginning. Each strip's width cyclically
+ * oscillates between `MIN_STRIP_WIDTH` and `MAX_STRIP_WIDTH` as it sweeps.
+ *
+ * @param length number of characters to generate
+ * @param options.startOffset where the first strip begins, as a fraction of `length` (0-1)
+ * @param options.intervalMs how often each strip advances to the next position, in ms
+ * @param options.count number of independent strips sweeping concurrently
+ * @returns the scrambled string, updated as the strips sweep
+ */
+export const useEncryptedText = (
+  length: number,
+  { startOffset = 0, intervalMs = SWEEP_INTERVAL_MS, count = 1 }: EncryptedTextSweepOptions = {},
+) => {
+  const [text, setText] = useState(() => CHARSET[0].repeat(length)) // static initial value to stop hydration mismatch
+
+  useEffect(() => {
+    setText(randomString(length))
+
+    const ids = Array.from({ length: count }, (_, section) => {
+      let cursor = Math.floor((startOffset + section / count) * length) % length
+      let tick = 0
+      const sectionIntervalMs = intervalMs + section * 7
+
+      return setInterval(() => {
+        const range = MAX_STRIP_WIDTH - MIN_STRIP_WIDTH
+        const phase = (tick / WIDTH_CYCLE_STEPS) * Math.PI * 2
+        const width = Math.round(MIN_STRIP_WIDTH + range * (0.5 + 0.5 * Math.sin(phase)))
+
+        setText((current) => {
+          const chars = current.split("")
+          for (let offset = 0; offset < width; offset++) {
+            const index = cursor + offset
+            if (index < length) chars[index] = randomChar()
+          }
+          return chars.join("")
+        })
+
+        cursor = (cursor + 1) % length
+        tick += 1
+      }, sectionIntervalMs)
+    })
+
+    return () => {
+      for (const id of ids) clearInterval(id)
+    }
+  }, [length, startOffset, intervalMs, count])
+
+  return text
+}

--- a/src/components/Generic/EncryptedBanner/variants.ts
+++ b/src/components/Generic/EncryptedBanner/variants.ts
@@ -1,0 +1,18 @@
+import { tv, type VariantProps } from "tailwind-variants"
+
+export const encryptedBannerLayerVariants = tv({
+  base: "pointer-events-none block w-full font-mono text-xs leading-none whitespace-nowrap select-none md:text-base",
+  variants: {
+    colour: {
+      pink: "text-brand-pink",
+      orange: "text-brand-orange",
+      purple: "text-brand-purple",
+      blue: "text-brand-blue",
+    },
+  },
+  defaultVariants: {
+    colour: "blue",
+  },
+})
+
+export type EncryptedBannerLayerVariants = VariantProps<typeof encryptedBannerLayerVariants>

--- a/src/components/Generic/index.ts
+++ b/src/components/Generic/index.ts
@@ -1,3 +1,4 @@
+export * from "./EncryptedBanner/EncryptedBanner"
 export * from "./EventCard/EventCard"
 export * from "./ExecCard/ExecCard"
 export * from "./Polaroid/Polaroid"

--- a/src/hooks/useContainerWidth.ts
+++ b/src/hooks/useContainerWidth.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { type RefObject, useEffect, useState } from "react"
+
+/**
+ * Tracks the rendered width (in pixels) of a container element.
+ *
+ * @param ref ref to the element to measure
+ * @returns the element's current content-box width, or 0 before it has been measured
+ */
+export const useContainerWidth = (ref: RefObject<HTMLElement | null>) => {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(entry.contentRect.width)
+    })
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [ref])
+
+  return width
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Tracks whether a CSS media query currently matches.
+ *
+ * @param query the media query to evaluate, e.g. "(min-width: 768px)"
+ * @returns whether the query matches (false before mount, to avoid a server/client hydration mismatch)
+ */
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query)
+    setMatches(mediaQueryList.matches)
+
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches)
+    mediaQueryList.addEventListener("change", onChange)
+    return () => mediaQueryList.removeEventListener("change", onChange)
+  }, [query])
+
+  return matches
+}


### PR DESCRIPTION
# Description

This PR adds the `EncryptedBanner` component, a decorative banner that displays a static "wavy" strip of random nonalphanumeric characters with optional overlayed bands. This also introduces two reusable utility hooks: `useMediaQuery` and `useContainerWidth`.

- adds `EncryptedBanner` component with support for 1 or 2 scrambled character bands
  - supports customizable colors (blue, pink, orange, purple) for primary and secondary bands
  - automatically fits character count to container width (or accepts explicit `length` prop)
  - renders with wave and sweep animations for a visually interesting effect
  - includes responsive font sizing: `text-xs` on mobile, `text-base` from `md` breakpoint up
- adds `useMediaQuery` hook to track CSS media query matches with proper hydration handling
- adds `useContainerWidth` hook to track container element width using ResizeObserver
- exports all three from `src/components/Generic/index.ts`
- includes Storybook stories with single-layer and double-layer variants

Closes #115 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<img width="1343" height="248" alt="Screenshot 2026-07-22 at 16 37 55" src="https://github.com/user-attachments/assets/c4285cda-e1bb-4908-a852-8722fe458735" />

https://github.com/user-attachments/assets/4ce68153-4bf9-4ee9-95be-130b8848f8fb

https://github.com/user-attachments/assets/3c732bcc-c50c-462b-8de5-b80fd238abeb

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
