### PR TITLE
refactor(api): migrate client-side data fetching to centralized api-client

### DIFF
--- a/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
+++ b/src/app/(frontend)/profile/_components/MemberDetailsForm.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react"
 import { ToggleableInput } from "@/components/Generic"
 import { Input, MultiSelect, Radio, Select } from "@/components/Primitive"
+import { ApiError } from "@/lib/api-client"
 import { toast } from "@/lib/toast"
 import type { Member } from "@/payload/payload-types"
-import { ProfileUpdateError, useUpdateMember } from "@/queries/useUpdateMember"
+import { useUpdateMember } from "@/queries/useUpdateMember"
 import type { UpdateMemberInput } from "@/types/schemas/member"
 
 const STUDY_YEAR_OPTIONS = [
@@ -49,24 +50,19 @@ export const MemberDetailsForm = ({ member }: { member: Member }) => {
       await mutateAsync({ [field]: value } as Partial<UpdateMemberInput>)
       toast.success({ description: "Profile updated" })
     } catch (err) {
-      if (err instanceof ProfileUpdateError && err.fieldErrors.length > 0) {
+      if (err instanceof ApiError && err.fieldErrors && err.fieldErrors.length > 0) {
         setErrors((prev) => {
           const next = { ...prev }
-          for (const fieldError of err.fieldErrors) {
-            next[fieldError.field] = fieldError.message
+          for (const fieldError of err.fieldErrors ?? []) {
+            next[fieldError.field as keyof UpdateMemberInput] = fieldError.message
           }
           return next
         })
-        if (!err.fieldErrors.some((fieldError) => fieldError.field === field)) {
-          toast.error({ description: err.message })
-        }
       } else {
         console.error("[MemberDetailsForm] saveField failed", { field, error: err })
         toast.error({
           description:
-            err instanceof ProfileUpdateError
-              ? err.message
-              : "An error occurred while updating your profile",
+            err instanceof ApiError ? err.message : "An error occurred while updating your profile",
         })
       }
       throw err

--- a/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
+++ b/src/components/Composite/SignUpForm/EmailVerificationStep.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { Button } from "@/components/Primitive"
 import { PinInput } from "@/components/Primitive/PinInput/PinInput"
+import { ApiError, api } from "@/lib/api-client"
 import { authClient } from "@/lib/auth-client"
 import { ApiRoutes, Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
@@ -50,25 +51,20 @@ export const EmailVerificationStep = () => {
     if (!step1) return
     setResendCooldown(RESEND_COOLDOWN_S)
     try {
-      const response = await fetch(ApiRoutes.SIGN_UP.VERIFICATION_CODE, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: step1.email }),
-      })
-      if (!response.ok) {
-        setResendCooldown(0)
-        if (response.status === 429) {
-          toast.warning({ description: "Please wait before requesting another code." })
-        } else {
-          toast.error({ description: "Failed to send verification email. Please try again." })
-        }
-        return
-      }
+      await api.post(
+        ApiRoutes.SIGN_UP.VERIFICATION_CODE,
+        { email: step1.email },
+        { toastOnError: false },
+      )
       startCooldown()
       toast.success({ description: "Verification email sent! Please check your inbox." })
-    } catch {
+    } catch (err) {
       setResendCooldown(0)
-      toast.error({ description: "Failed to send verification email. Please try again." })
+      if (err instanceof ApiError && err.status === 429) {
+        toast.warning({ description: "Please wait before requesting another code." })
+      } else {
+        toast.error({ description: "Failed to send verification email. Please try again." })
+      }
     }
   }
 
@@ -95,15 +91,15 @@ export const EmailVerificationStep = () => {
 
     setSubmitting(true)
     try {
-      const verifyResponse = await fetch(ApiRoutes.SIGN_UP.VERIFICATION_CODE, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: step1.email, code }),
-      })
-
-      if (!verifyResponse.ok) {
-        const body = await verifyResponse.json()
-        if (body?.error === "expired") {
+      let verifyResult: { memberExists: boolean }
+      try {
+        verifyResult = await api.put<{ memberExists: boolean }>(
+          ApiRoutes.SIGN_UP.VERIFICATION_CODE,
+          { email: step1.email, code },
+          { toastOnError: false },
+        )
+      } catch (err) {
+        if (err instanceof ApiError && err.message === "expired") {
           toast.warning({ description: "Your code has expired. Please request a new one." })
         } else {
           toast.warning({ description: "Incorrect code. Please check your email and try again." })
@@ -111,17 +107,17 @@ export const EmailVerificationStep = () => {
         return
       }
 
-      const { memberExists } = await verifyResponse.json()
+      const { memberExists } = verifyResult
 
       if (memberExists) {
-        const signUpResponse = await fetch(ApiRoutes.SIGN_UP.ROOT, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...step1, existingMember: true }),
-        })
-
-        if (!signUpResponse.ok) {
-          if (signUpResponse.status === 409) {
+        try {
+          await api.post(
+            ApiRoutes.SIGN_UP.ROOT,
+            { ...step1, existingMember: true },
+            { toastOnError: false },
+          )
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 409) {
             toast.warning({
               description:
                 "This email is already in use.\nIf you think this is a mistake, please contact us at admin@uoacs.co.nz",

--- a/src/components/Composite/SignUpForm/MemberStep.tsx
+++ b/src/components/Composite/SignUpForm/MemberStep.tsx
@@ -11,6 +11,7 @@ import { Button, Radio } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
 import { MultiSelect } from "@/components/Primitive/MultiSelect/MultiSelect"
 import { Select } from "@/components/Primitive/Select/Select"
+import { ApiError, api } from "@/lib/api-client"
 import { authClient } from "@/lib/auth-client"
 import { ApiRoutes, Routes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
@@ -72,22 +73,7 @@ export const MemberStep = () => {
     setStep2(step2Data)
     setLoading(true)
     try {
-      const response = await fetch(ApiRoutes.SIGN_UP.ROOT, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...step1, ...step2Data }),
-      })
-      if (!response.ok) {
-        if (response.status === 409) {
-          toast.warning({
-            description:
-              "This email is already in use.\nIf you think this is a mistake, please contact us at admin@uoacs.co.nz",
-          })
-        } else {
-          toast.error({ description: "An error occurred while submitting the form" })
-        }
-        return
-      }
+      await api.post(ApiRoutes.SIGN_UP.ROOT, { ...step1, ...step2Data }, { toastOnError: false })
       reset()
       const { data: session, error } = await authClient.getSession()
       if (!session || error) {
@@ -104,8 +90,15 @@ export const MemberStep = () => {
       toast.success({
         description: "Successfully signed up!\nWe look forward to seeing you at our events!!",
       })
-    } catch {
-      toast.error({ description: "An error occurred while submitting the form" })
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        toast.warning({
+          description:
+            "This email is already in use.\nIf you think this is a mistake, please contact us at admin@uoacs.co.nz",
+        })
+      } else {
+        toast.error({ description: "An error occurred while submitting the form" })
+      }
     } finally {
       setLoading(false)
     }

--- a/src/components/Composite/SignUpForm/UserStep.tsx
+++ b/src/components/Composite/SignUpForm/UserStep.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form"
 import type { z } from "zod"
 import { Button } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
+import { ApiError, api } from "@/lib/api-client"
 import { ApiRoutes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import { createUserSchema } from "@/types/schemas/user"
@@ -36,22 +37,18 @@ export const UserStep = () => {
     setSubmitting(true)
     try {
       setStep1(userData)
-      const response = await fetch(ApiRoutes.SIGN_UP.VERIFICATION_CODE, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: userData.email }),
-      })
-      if (!response.ok) {
-        if (response.status === 429) {
-          toast.warning({ description: "Please wait before requesting another code." })
-        } else {
-          toast.error({ description: "Failed to send verification email. Please try again." })
-        }
-        return
-      }
+      await api.post(
+        ApiRoutes.SIGN_UP.VERIFICATION_CODE,
+        { email: userData.email },
+        { toastOnError: false },
+      )
       nextStep()
-    } catch {
-      toast.error({ description: "An error occurred while submitting the form" })
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 429) {
+        toast.warning({ description: "Please wait before requesting another code." })
+      } else {
+        toast.error({ description: "Failed to send verification email. Please try again." })
+      }
     } finally {
       setSubmitting(false)
     }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -20,6 +20,7 @@ type RequestOptions = {
   params?: Record<string, string | number | boolean | undefined | null>
   cache?: RequestCache
   next?: NextFetchRequestConfig
+  toastOnError?: boolean
 }
 
 function buildUrlWithParams(url: string, params?: RequestOptions["params"]): string {
@@ -33,7 +34,15 @@ function buildUrlWithParams(url: string, params?: RequestOptions["params"]): str
 }
 
 async function fetchApi<T>(url: string, options: RequestOptions = {}): Promise<T> {
-  const { method = "GET", headers = {}, body, params, cache = "no-store", next } = options
+  const {
+    method = "GET",
+    headers = {},
+    body,
+    params,
+    cache = "no-store",
+    next,
+    toastOnError = true,
+  } = options
 
   const fullUrl = buildUrlWithParams(url, params)
 
@@ -59,7 +68,7 @@ async function fetchApi<T>(url: string, options: RequestOptions = {}): Promise<T
         ? responseBody.error
         : response.statusText
 
-    if (typeof window !== "undefined") {
+    if (toastOnError && typeof window !== "undefined") {
       toast.error({ description: message })
     }
 
@@ -68,7 +77,9 @@ async function fetchApi<T>(url: string, options: RequestOptions = {}): Promise<T
 
   if (response.status === 204) return undefined as T
 
-  return response.json()
+  return response.json().catch(() => {
+    throw new ApiError("Received an invalid response from the server", response.status)
+  })
 }
 
 export const api = {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,90 @@
+import { toast } from "@/lib/toast"
+
+export type ApiFieldError = { field: string; message: string }
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly fieldErrors?: ApiFieldError[],
+  ) {
+    super(message)
+    this.name = "ApiError"
+  }
+}
+
+type RequestOptions = {
+  method?: string
+  headers?: Record<string, string>
+  body?: unknown
+  params?: Record<string, string | number | boolean | undefined | null>
+  cache?: RequestCache
+  next?: NextFetchRequestConfig
+}
+
+function buildUrlWithParams(url: string, params?: RequestOptions["params"]): string {
+  if (!params) return url
+  const filteredParams = Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null),
+  )
+  if (Object.keys(filteredParams).length === 0) return url
+  const queryString = new URLSearchParams(filteredParams as Record<string, string>).toString()
+  return `${url}?${queryString}`
+}
+
+async function fetchApi<T>(url: string, options: RequestOptions = {}): Promise<T> {
+  const { method = "GET", headers = {}, body, params, cache = "no-store", next } = options
+
+  const fullUrl = buildUrlWithParams(url, params)
+
+  const response = await fetch(fullUrl, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    credentials: "include",
+    cache,
+    next,
+  })
+
+  if (!response.ok) {
+    const responseBody = await response.json().catch(() => null)
+    const fieldErrors = Array.isArray(responseBody?.error) ? responseBody.error : undefined
+    const message = fieldErrors
+      ? "Validation failed"
+      : typeof responseBody?.error === "string"
+        ? responseBody.error
+        : response.statusText
+
+    if (typeof window !== "undefined") {
+      toast.error({ description: message })
+    }
+
+    throw new ApiError(message, response.status, fieldErrors)
+  }
+
+  if (response.status === 204) return undefined as T
+
+  return response.json()
+}
+
+export const api = {
+  get<T>(url: string, options?: RequestOptions): Promise<T> {
+    return fetchApi<T>(url, { ...options, method: "GET" })
+  },
+  post<T>(url: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return fetchApi<T>(url, { ...options, method: "POST", body })
+  },
+  put<T>(url: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return fetchApi<T>(url, { ...options, method: "PUT", body })
+  },
+  patch<T>(url: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return fetchApi<T>(url, { ...options, method: "PATCH", body })
+  },
+  delete<T>(url: string, options?: RequestOptions): Promise<T> {
+    return fetchApi<T>(url, { ...options, method: "DELETE" })
+  },
+}

--- a/src/payload/components/DeleteMemberButton.tsx
+++ b/src/payload/components/DeleteMemberButton.tsx
@@ -3,6 +3,7 @@
 import { Button, useDocumentInfo } from "@payloadcms/ui"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
+import { ApiError, api } from "@/lib/api-client"
 import { ApiRoutes } from "@/lib/routes"
 
 export function DeleteMemberButton() {
@@ -18,16 +19,10 @@ export function DeleteMemberButton() {
     setError(null)
 
     try {
-      const res = await fetch(ApiRoutes.ADMIN.MEMBERS(id), { method: "DELETE" })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        setError(body.error ?? `Delete failed (${res.status})`)
-        setConfirming(false)
-        return
-      }
+      await api.delete(ApiRoutes.ADMIN.MEMBERS(id), { toastOnError: false })
       router.push("/payload/admin/collections/member")
-    } catch {
-      setError("Unexpected error — please try again")
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Unexpected error — please try again")
       setConfirming(false)
     } finally {
       setLoading(false)

--- a/src/queries/useMember.ts
+++ b/src/queries/useMember.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api-client"
 import { ApiRoutes } from "@/lib/routes"
 import type { Member } from "@/payload/payload-types"
 import { QueryKeys } from "./QueryKeys"
@@ -6,11 +7,7 @@ import { QueryKeys } from "./QueryKeys"
 export function useMember(userId: string) {
   return useQuery<Member>({
     queryKey: [QueryKeys.MEMBER, userId],
-    queryFn: async () => {
-      const result = await fetch(ApiRoutes.MEMBER.ME)
-      if (!result.ok) throw new Error(`Failed to fetch member: ${result.status}`)
-      return result.json()
-    },
+    queryFn: async () => api.get<Member>(ApiRoutes.MEMBER.ME),
     enabled: !!userId,
   })
 }

--- a/src/queries/useUpdateMember.ts
+++ b/src/queries/useUpdateMember.ts
@@ -1,43 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { type ApiError, api } from "@/lib/api-client"
 import { ApiRoutes } from "@/lib/routes"
 import type { Member } from "@/payload/payload-types"
 import type { UpdateMemberInput } from "@/types/schemas/member"
 import { QueryKeys } from "./QueryKeys"
 
-export type ProfileFieldError = { field: keyof UpdateMemberInput; message: string }
-
-export class ProfileUpdateError extends Error {
-  constructor(
-    public readonly fieldErrors: ProfileFieldError[],
-    message = "Failed to update profile",
-  ) {
-    super(message)
-    this.name = "ProfileUpdateError"
-  }
-}
-
 export function useUpdateMember() {
   const queryClient = useQueryClient()
 
-  return useMutation<Member, ProfileUpdateError, Partial<UpdateMemberInput>>({
-    mutationFn: async (data) => {
-      const response = await fetch(ApiRoutes.PROFILE, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        const body = await response.json().catch(() => null)
-        if (Array.isArray(body?.error)) {
-          throw new ProfileUpdateError(body.error)
-        }
-        const message = typeof body?.error === "string" ? body.error : undefined
-        throw new ProfileUpdateError([], message)
-      }
-      return response.json().catch(() => {
-        throw new ProfileUpdateError([], "Received an invalid response from the server")
-      })
-    },
+  return useMutation<Member, ApiError, Partial<UpdateMemberInput>>({
+    mutationFn: (data) => api.patch<Member>(ApiRoutes.PROFILE, data, { toastOnError: false }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKeys.MEMBER] })
     },


### PR DESCRIPTION
# Description

This PR migrates client-side data fetching from raw `fetch()` calls to a shared `api-client` helper that provides consistent error handling, type safety, and per-call configuration.

- adds `src/lib/api-client.ts` (renamed from `api.ts`) with a unified `api` export providing `get()`, `post()`, `put()`, `patch()`, and `delete()` methods
- introduces `ApiError` class that captures HTTP status codes, error messages, and field-level validation errors in a structured way
- adds `toastOnError` option (defaults to `true`) so callers can suppress the automatic error toast for inline error rendering
- removes the bespoke `ProfileUpdateError` class from `useUpdateMember`, replacing it with `ApiError`
- updates all components and hooks to use `api-client`:
  - `src/queries/useMember.ts` — simplifies the query function
  - `src/queries/useUpdateMember.ts` — removes error handling boilerplate
  - `src/app/(frontend)/profile/_components/MemberDetailsForm.tsx` — uses `ApiError` instead of `ProfileUpdateError`
  - `src/payload/components/DeleteMemberButton.tsx` — removes raw fetch and inline error parsing
  - `src/components/Composite/SignUpForm/UserStep.tsx` — centralizes verification email requests
  - `src/components/Composite/SignUpForm/MemberStep.tsx` — centralizes member creation
  - `src/components/Composite/SignUpForm/EmailVerificationStep.tsx` — centralizes email verification flow

Status-code branching is preserved per call site (e.g. 429 rate limit, 409 conflict, expired code) via `ApiError.status` and `ApiError.message`, with `toastOnError: false` used wherever the caller renders its own inline error UI.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
