### PR TITLE
fix(storybook): add SessionContext provider and logged-in story variants

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,0 +1,18 @@
+import type { Decorator } from "@storybook/nextjs-vite"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { type Session, SessionContext } from "@/context/SessionContext"
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+export const withProviders: Decorator = (Story, context) => {
+  const session = (context.parameters.session as Session | undefined) ?? null
+  return (
+    <SessionContext.Provider value={session}>
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    </SessionContext.Provider>
+  )
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,8 +1,10 @@
 import type { Preview } from "@storybook/nextjs-vite"
+import { withProviders } from "./decorators"
 import "../src/app/globals.css"
 import "./fonts.css"
 
 const preview: Preview = {
+  decorators: [withProviders],
   parameters: {
     controls: {
       matchers: {

--- a/src/components/Composite/AboutUsSection/AboutUsSection.stories.tsx
+++ b/src/components/Composite/AboutUsSection/AboutUsSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/nextjs-vite"
 import { mockReel } from "@/mocks/Reel.mock"
+import { mockSession } from "@/mocks/Session.mock"
 import { AboutUsSection } from "./AboutUsSection"
 
 const meta: Meta<typeof AboutUsSection> = {
@@ -21,3 +22,12 @@ export const Default: Story = (args) => {
     </div>
   )
 }
+
+export const LoggedIn: Story = (args) => {
+  return (
+    <div className="mt-55">
+      <AboutUsSection {...args} />
+    </div>
+  )
+}
+LoggedIn.parameters = { session: mockSession }

--- a/src/components/Composite/Footer/Footer.stories.tsx
+++ b/src/components/Composite/Footer/Footer.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
 import { SOCIAL_ICONS } from "@/components/Primitive"
 import { Routes } from "@/lib/routes"
+import { mockSession } from "@/mocks/Session.mock"
 import { Footer } from "./Footer"
 
 const meta: Meta<typeof Footer> = {
@@ -42,4 +43,9 @@ type Story = StoryObj<typeof Footer>
 
 export const Default: Story = {
   args: {},
+}
+
+export const LoggedIn: Story = {
+  args: {},
+  parameters: { session: mockSession },
 }

--- a/src/components/Composite/Navbar/Navbar.stories.tsx
+++ b/src/components/Composite/Navbar/Navbar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
 import { SOCIAL_ICONS } from "@/components/Primitive"
 import { Routes } from "@/lib/routes"
+import { mockSession } from "@/mocks/Session.mock"
 import { Navbar } from "./Navbar"
 
 const meta: Meta<typeof Navbar> = {
@@ -45,3 +46,7 @@ export default meta
 type Story = StoryObj<typeof Navbar>
 
 export const Primary: Story = {}
+
+export const LoggedIn: Story = {
+  parameters: { session: mockSession },
+}

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -3,7 +3,7 @@ import { authClient } from "@/lib/auth-client"
 
 export type Session = typeof authClient.$Infer.Session | null
 
-const SessionContext = createContext<Session | undefined>(undefined)
+export const SessionContext = createContext<Session | undefined>(undefined)
 
 export function useSession(): Session {
   const context = useContext(SessionContext)

--- a/src/mocks/Session.mock.ts
+++ b/src/mocks/Session.mock.ts
@@ -1,0 +1,23 @@
+import type { Session } from "@/context/SessionContext"
+
+export const mockSession: Session = {
+  user: {
+    id: "usr_01j8x9k2mgqf5s0y7c3n4h8v6z",
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+    updatedAt: new Date("2026-01-15T10:00:00Z"),
+    email: "test@uoacs.example.com",
+    emailVerified: true,
+    name: "Jane Doe",
+    image: null,
+  },
+  session: {
+    id: "ses_01j8xa1p3wqf6t1z8d4o5j9w7a",
+    createdAt: new Date("2026-07-23T09:00:00Z"),
+    updatedAt: new Date("2026-07-23T09:00:00Z"),
+    userId: "usr_01j8x9k2mgqf5s0y7c3n4h8v6z",
+    expiresAt: new Date("2026-08-06T09:00:00Z"),
+    token: "mock-session-token",
+    ipAddress: "127.0.0.1",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+  },
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes towards the related issue. Please also include relevant context. -->

This PR provides a `SessionContext` in Storybook so `useSession` doesn't throw when rendering components that read the session, and adds `LoggedIn` story variants to verify authenticated states.

- adds `withProviders` decorator in `.storybook/decorators.tsx` that wraps stories with `SessionContext.Provider` and `QueryClientProvider`
- registers `withProviders` globally in `.storybook/preview.ts`
- exports `SessionContext` from `src/context/SessionContext.tsx` so the decorator can provide it
- adds a `mockSession` fixture at `src/mocks/Session.mock.ts`
- adds `LoggedIn` story variants for `Navbar`, `Footer`, and `AboutUsSection` using `mockSession`

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [x] Unit/Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member
