### PR TITLE
refactor(queries): use api-client in useEvents hook

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -23,6 +23,11 @@ type RequestOptions = {
   toastOnError?: boolean
 }
 
+function resolveUrl(url: string): string {
+  if (typeof window !== "undefined") return url
+  return `${process.env.NEXT_PUBLIC_URL}${url}`
+}
+
 function buildUrlWithParams(url: string, params?: RequestOptions["params"]): string {
   if (!params) return url
   const filteredParams = Object.fromEntries(
@@ -44,7 +49,7 @@ async function fetchApi<T>(url: string, options: RequestOptions = {}): Promise<T
     toastOnError = true,
   } = options
 
-  const fullUrl = buildUrlWithParams(url, params)
+  const fullUrl = buildUrlWithParams(resolveUrl(url), params)
 
   const response = await fetch(fullUrl, {
     method,

--- a/src/queries/useEvents.ts
+++ b/src/queries/useEvents.ts
@@ -1,5 +1,6 @@
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query"
 import type { PaginatedDocs } from "payload"
+import { api } from "@/lib/api-client"
 import { ApiRoutes } from "@/lib/routes"
 import type { Event } from "@/payload/payload-types"
 import { QueryKeys } from "./QueryKeys"
@@ -7,11 +8,10 @@ import { QueryKeys } from "./QueryKeys"
 export const getEventsQueryOptions = (upcoming: boolean) =>
   infiniteQueryOptions({
     queryKey: [QueryKeys.EVENTS, upcoming],
-    queryFn: async ({ pageParam }) => {
-      const result = await fetch(ApiRoutes.EVENTS(upcoming, pageParam))
-      if (!result.ok) throw new Error(`Failed to fetch events: ${result.status}`)
-      return result.json() as Promise<PaginatedDocs<Event>>
-    },
+    queryFn: ({ pageParam }) =>
+      api.get<PaginatedDocs<Event>>(ApiRoutes.EVENTS(upcoming, pageParam), {
+        toastOnError: false,
+      }),
     initialPageParam: 1,
     getNextPageParam: (lastPage: PaginatedDocs<Event>) =>
       lastPage.hasNextPage ? lastPage.nextPage : undefined,


### PR DESCRIPTION
# Description

This PR refactors the `useEvents` hook to use the centralized `api-client` instead of raw `fetch()` calls, continuing the migration effort introduced in PR #344, and fixes a bug in `api-client` where server-side requests were being silently dropped.

- replaces raw `fetch()` with `api.get()` in the `useEvents` query function
- removes manual error handling that's now delegated to the `api-client`
- adds `toastOnError: false` to suppress toast notifications on errors while maintaining consistent error handling through the api-client
- fixes `fetchApi()` in `api-client` to resolve relative URLs to absolute ones when running server-side (`resolveUrl()`), since Node's `fetch()` has no page origin to resolve a relative path against
  - without this, `queryClient.prefetchInfiniteQuery()` on the `/events` page was silently failing during SSR (`prefetchQuery` swallows `queryFn` errors), so `dehydrate()` had no data to hand off — the server-rendered HTML shipped to crawlers/no-JS clients was just the loading skeleton, with real event data only appearing after client-side hydration re-fetched it
  - confirmed with `curl localhost:3000/events`: before the fix the SSR HTML had zero event markup, after it renders real event cards (names, images) directly in the initial HTML

Relates to #344

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Verified with `curl http://localhost:3000/events`, stripping `<script>` tags from the response to inspect only the actual server-rendered DOM — confirmed real event names, images, and card markup are present in the initial HTML (previously only loading skeletons). Also manually verified pagination and error toasts still work as expected through the `api-client` interface.
