### PR TITLE
fix(robots): guard payload admin/api and app api/profile routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: "/admin/",
+        disallow: ["/payload/admin/", "/payload/api/", "/api/", "/profile/"],
       },
     ],
     sitemap: `${process.env.NEXT_PUBLIC_URL}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,8 +1,20 @@
 import type { MetadataRoute } from "next"
+import { isProductionUrl } from "@/lib/helpers"
 
 export const dynamic = "force-static"
 
 export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_URL
+
+  if (!isProductionUrl(baseUrl)) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    }
+  }
+
   return {
     rules: [
       {
@@ -11,6 +23,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/payload/admin/", "/payload/api/", "/api/", "/profile/"],
       },
     ],
-    sitemap: `${process.env.NEXT_PUBLIC_URL}/sitemap.xml`,
+    sitemap: `${baseUrl}/sitemap.xml`,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next"
+import { isProductionUrl } from "@/lib/helpers"
 import { Routes } from "@/lib/routes"
 
 export const dynamic = "force-static"
@@ -6,7 +7,7 @@ export const dynamic = "force-static"
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = process.env.NEXT_PUBLIC_URL
 
-  if (!baseUrl) {
+  if (!isProductionUrl(baseUrl)) {
     return []
   }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,7 @@
 import { SponsorTier } from "@/types/enums"
 
+export const PRODUCTION_HOSTNAME = "uoacs.co.nz"
+
 export const TIER_SIZES: Record<SponsorTier, { height: number; width: number }> = {
   [SponsorTier.DIAMOND]: {
     height: 120,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,7 +1,17 @@
 import type { SocialLink } from "@/components/Generic"
 import { type DiscordWidgetData, discordWidgetDataSchema } from "@/types/schemas/discord"
+import { PRODUCTION_HOSTNAME } from "./constants"
 import { payload } from "./payload"
 import { Slugs } from "./slugs"
+
+export function isProductionUrl(baseUrl: string | undefined): baseUrl is string {
+  if (!baseUrl) return false
+  try {
+    return new URL(baseUrl).hostname === PRODUCTION_HOSTNAME
+  } catch {
+    return false
+  }
+}
 
 export async function getSocialLinks(): Promise<SocialLink[]> {
   const { discordHref, instagramHref, tiktokHref, linkedinHref } = await payload.findGlobal({


### PR DESCRIPTION
# Description

This PR fixes `robots.ts` to guard the routes that actually exist instead of a dead `/admin` path, and gates `robots.ts`/`sitemap.ts` so non-production deploys don't get indexed.

- replaces `disallow: "/admin/"` (route doesn't exist in this app) with `/payload/admin/`, the real CMS admin path
- adds `/payload/api/` — the CMS's own API routes
- adds `/api/` — this app's API routes (auth, member, sign-up, google-wallet, admin, profile)
- adds `/profile/` — user-specific page, no SEO value
- adds `isProductionUrl()` in `src/lib/helpers.ts`, used by both `robots.ts` and `sitemap.ts` to check `NEXT_PUBLIC_URL` against the production hostname
  - preview/staging deploys now fall back to `disallow: "/"` (robots) and an empty sitemap instead of being indexed
  - the URL parse is wrapped in a try/catch so a malformed `NEXT_PUBLIC_URL` degrades to the safe fallback instead of crashing the static build
- moves `PRODUCTION_HOSTNAME` into `src/lib/constants.ts` so it's shared rather than duplicated across the two route files

Not related to a ticket

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Confirmed `src/app/robots.ts` `disallow` array now lists `/payload/admin/`, `/payload/api/`, `/api/`, `/profile/`. Verified `isProductionUrl()` returns `false` (safe fallback) for unset, malformed, and wrong-hostname values, and `true` only for `https://uoacs.co.nz`. `pnpm types:check` passes. Can verify post-deploy with `curl https://<site>/robots.txt` and `curl https://<site>/sitemap.xml`.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member
