### PR TITLE
feat(form): add keyboard navigation to select, dropdown, and multiselect

### DIFF
--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -72,6 +72,10 @@ export const Dropdown = ({
     itemRefs: optionRefs,
   })
 
+  useEffect(() => {
+    if (isOpen) triggerRef.current?.focus()
+  }, [isOpen])
+
   const triggerClassName = trigger !== false ? trigger?.triggerClassName : undefined
   const triggerRight =
     trigger === false

--- a/src/components/Primitive/Dropdown/Dropdown.tsx
+++ b/src/components/Primitive/Dropdown/Dropdown.tsx
@@ -3,6 +3,7 @@
 import { ChevronDownIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion, stagger } from "motion/react"
 import { type ReactNode, useEffect, useRef, useState } from "react"
+import { usePopoverKeyboardNav } from "@/hooks/usePopoverKeyboardNav"
 import { cn } from "@/lib/utils"
 import { Button } from "../Button/Button"
 import type { ButtonVariantProps } from "../Button/variants"
@@ -46,6 +47,8 @@ export const Dropdown = ({
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<(HTMLElement | null)[]>([])
 
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
@@ -62,6 +65,13 @@ export const Dropdown = ({
     }
   }, [])
 
+  const onKeyDown = usePopoverKeyboardNav({
+    isOpen,
+    onClose: () => setIsOpen(false),
+    triggerRef,
+    itemRefs: optionRefs,
+  })
+
   const triggerClassName = trigger !== false ? trigger?.triggerClassName : undefined
   const triggerRight =
     trigger === false
@@ -71,11 +81,13 @@ export const Dropdown = ({
         ))
 
   return (
-    <div className="relative inline-flex" ref={ref}>
+    // biome-ignore lint/a11y/noStaticElementInteractions: delegates keydown from the trigger/menu items below to the shared popover nav handler
+    <div className="relative inline-flex" onKeyDown={onKeyDown} ref={ref}>
       <Button
         aria-expanded={isOpen}
         className={cn("z-20", triggerClassName)}
         onClick={() => setIsOpen(!isOpen)}
+        ref={triggerRef}
         right={triggerRight}
         {...buttonVariantProps}
       >
@@ -104,7 +116,7 @@ export const Dropdown = ({
               closed: { opacity: 0, y: -5 },
             }}
           >
-            {options.map((option) => (
+            {options.map((option, i) => (
               <motion.div
                 key={option.href ?? option.label?.toString()}
                 variants={{
@@ -112,7 +124,12 @@ export const Dropdown = ({
                   closed: { opacity: 0, y: -5 },
                 }}
               >
-                <DropdownOption {...option} />
+                <DropdownOption
+                  {...option}
+                  ref={(el) => {
+                    optionRefs.current[i] = el
+                  }}
+                />
               </motion.div>
             ))}
           </motion.div>

--- a/src/components/Primitive/Dropdown/DropdownOption.tsx
+++ b/src/components/Primitive/Dropdown/DropdownOption.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import type { Ref } from "react"
 import { cn } from "@/lib/utils"
 import { Button } from "../Button/Button"
 import { type ButtonVariantProps, buttonVariants } from "../Button/variants"
@@ -19,6 +20,10 @@ export interface DropdownOptionProps extends ButtonVariantProps {
    * An optional click handler for the dropdown option.
    */
   onClick?: () => void
+  /**
+   * A ref to the underlying link/button element, used for keyboard roving focus.
+   */
+  ref?: Ref<HTMLElement>
 }
 
 /**
@@ -27,13 +32,19 @@ export interface DropdownOptionProps extends ButtonVariantProps {
  * @param props {@link DropdownOptionProps} for the DropdownOption component.
  * @returns A styled dropdown option element.
  */
-export const DropdownOption = ({ label, href, onClick, ...variant }: DropdownOptionProps) => {
+export const DropdownOption = ({ label, href, onClick, ref, ...variant }: DropdownOptionProps) => {
+  const setRef = (el: HTMLElement | null) => {
+    if (typeof ref === "function") ref(el)
+    else if (ref) ref.current = el
+  }
+
   if (href) {
     const variantClasses = buttonVariants(variant)
     const isExternal = href.startsWith("http")
     return (
       <Link
         href={href}
+        ref={setRef}
         rel={isExternal ? "noopener noreferrer" : undefined}
         role="menuitem"
         target={isExternal ? "_blank" : "_self"}
@@ -44,7 +55,13 @@ export const DropdownOption = ({ label, href, onClick, ...variant }: DropdownOpt
   }
 
   return (
-    <Button className="z-5 whitespace-nowrap" onClick={onClick} role="menuitem" {...variant}>
+    <Button
+      className="z-5 whitespace-nowrap"
+      onClick={onClick}
+      ref={setRef}
+      role="menuitem"
+      {...variant}
+    >
       {label || "Option"}
     </Button>
   )

--- a/src/components/Primitive/MultiSelect/MultiSelect.tsx
+++ b/src/components/Primitive/MultiSelect/MultiSelect.tsx
@@ -3,6 +3,7 @@
 import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion } from "motion/react"
 import { type Ref, useEffect, useRef, useState } from "react"
+import { usePopoverKeyboardNav } from "@/hooks/usePopoverKeyboardNav"
 import { cn } from "@/lib/utils"
 import { Button } from "../Button/Button"
 
@@ -16,7 +17,7 @@ interface MultiSelectProps {
   containerClassName?: string
   required?: boolean
   placeholder?: string
-  ref?: Ref<HTMLButtonElement>
+  ref?: Ref<HTMLDivElement>
 }
 
 export const MultiSelect = ({
@@ -34,6 +35,8 @@ export const MultiSelect = ({
   const [isOpen, setIsOpen] = useState(false)
   const [customValue, setCustomValue] = useState("")
   const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLDivElement>(null)
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([])
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
@@ -45,6 +48,13 @@ export const MultiSelect = ({
     return () => document.removeEventListener("mousedown", handleMouseDown)
   }, [])
 
+  const onKeyDown = usePopoverKeyboardNav({
+    isOpen,
+    onClose: () => setIsOpen(false),
+    triggerRef,
+    itemRefs: optionRefs,
+  })
+
   const toggle = (option: string) => {
     if (value.includes(option)) {
       onChange(value.filter((v) => v !== option))
@@ -54,13 +64,29 @@ export const MultiSelect = ({
   }
 
   const multiSelectControl = (
-    <div className="relative">
-      <button
+    // biome-ignore lint/a11y/noStaticElementInteractions: delegates keydown from the trigger/options below to the shared popover nav handler
+    <div className="relative" onKeyDown={onKeyDown}>
+      {/* biome-ignore lint/a11y/useSemanticElements: can't be a <button> since it contains real nested <button> chip-remove controls */}
+      <div
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
         className="flex min-h-11 w-full flex-wrap items-center gap-1.5 rounded border border-gray-300 px-3 py-2 text-left"
         id={label || undefined}
         onClick={() => setIsOpen((prev) => !prev)}
-        ref={ref}
-        type="button"
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            setIsOpen((prev) => !prev)
+          }
+        }}
+        ref={(el) => {
+          triggerRef.current = el
+          if (typeof ref === "function") ref(el)
+          else if (ref) ref.current = el
+        }}
+        role="button"
+        tabIndex={0}
       >
         {value.length === 0 ? (
           <span className="text-gray-400 text-sm">{placeholder}</span>
@@ -71,12 +97,17 @@ export const MultiSelect = ({
               key={v}
             >
               {v}
-              <XMarkIcon
-                className="h-4 w-4"
-                onClick={() => {
+              <button
+                aria-label={`Remove ${v}`}
+                className="flex items-center justify-center"
+                onClick={(e) => {
+                  e.stopPropagation()
                   toggle(v)
                 }}
-              />
+                type="button"
+              >
+                <XMarkIcon className="h-4 w-4" />
+              </button>
             </span>
           ))
         )}
@@ -86,23 +117,30 @@ export const MultiSelect = ({
             isOpen && "rotate-180",
           )}
         />
-      </button>
+      </div>
       <AnimatePresence>
         {isOpen && (
           <motion.ul
             animate={{ opacity: 1, y: 0 }}
+            aria-multiselectable="true"
             className="absolute top-full z-10 mt-1 w-full rounded border border-gray-200 bg-white py-2 shadow-md"
             exit={{ opacity: 0, y: -4 }}
             initial={{ opacity: 0, y: -4 }}
+            role="listbox"
             transition={{ damping: 25, stiffness: 400, type: "spring" }}
           >
-            {options.map((option) => {
+            {options.map((option, i) => {
               const checked = value.includes(option)
               return (
                 <li key={option}>
                   <button
+                    aria-selected={checked}
                     className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors duration-300 hover:bg-gray-400-opaque"
                     onClick={() => toggle(option)}
+                    ref={(el) => {
+                      optionRefs.current[i] = el
+                    }}
+                    role="option"
                     type="button"
                   >
                     <span
@@ -182,7 +220,12 @@ export const MultiSelect = ({
       className={cn("flex w-full flex-col justify-start gap-1 font-mono", containerClassName)}
       ref={containerRef}
     >
-      <label className="font-medium text-gray-700 text-sm" htmlFor={label}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: only refocuses the already keyboard-operable trigger div, not itself an interactive target */}
+      <label
+        className="font-medium text-gray-700 text-sm"
+        htmlFor={label}
+        onClick={() => triggerRef.current?.focus()}
+      >
         {label}
         {required && <span className="ml-1 text-brand-pink">*</span>}
       </label>

--- a/src/components/Primitive/MultiSelect/MultiSelect.tsx
+++ b/src/components/Primitive/MultiSelect/MultiSelect.tsx
@@ -74,6 +74,7 @@ export const MultiSelect = ({
       <div
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        aria-label={label}
         className="flex min-h-11 w-full flex-wrap items-center gap-1.5 rounded border border-gray-300 px-3 py-2 text-left"
         id={label || undefined}
         onClick={() => setIsOpen((prev) => !prev)}

--- a/src/components/Primitive/MultiSelect/MultiSelect.tsx
+++ b/src/components/Primitive/MultiSelect/MultiSelect.tsx
@@ -55,6 +55,10 @@ export const MultiSelect = ({
     itemRefs: optionRefs,
   })
 
+  useEffect(() => {
+    if (isOpen) triggerRef.current?.focus()
+  }, [isOpen])
+
   const toggle = (option: string) => {
     if (value.includes(option)) {
       onChange(value.filter((v) => v !== option))

--- a/src/components/Primitive/PinInput/PinInput.tsx
+++ b/src/components/Primitive/PinInput/PinInput.tsx
@@ -118,6 +118,12 @@ export const PinInput = ({
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault()
     const raw = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, length)
+
+    if (raw.length === 0) {
+      commit([...slotsRef.current])
+      return
+    }
+
     const next = raw.split("").concat(Array(length).fill("")).slice(0, length)
     commit(next)
     inputRefs.current[Math.min(raw.length, length - 1)]?.focus()

--- a/src/components/Primitive/PinInput/PinInput.tsx
+++ b/src/components/Primitive/PinInput/PinInput.tsx
@@ -48,6 +48,8 @@ export const PinInput = ({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, i: number) => {
+    if (e.ctrlKey || e.metaKey) return
+
     if (e.key >= "0" && e.key <= "9") {
       e.preventDefault()
       const next = [...slots]

--- a/src/components/Primitive/Radio/RadioOption.tsx
+++ b/src/components/Primitive/Radio/RadioOption.tsx
@@ -15,7 +15,7 @@ export const RadioOption = ({ option, checked, toggle, name, required }: RadioOp
     <label className="group flex w-fit cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm">
       <input
         checked={checked}
-        className="sr-only"
+        className="peer sr-only"
         name={name}
         onChange={() => toggle(option)}
         required={required}
@@ -24,7 +24,7 @@ export const RadioOption = ({ option, checked, toggle, name, required }: RadioOp
       />
       <span
         className={cn(
-          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-300 group-hover:bg-gray-200",
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-300 group-hover:bg-gray-200 peer-focus-visible:ring-2 peer-focus-visible:ring-brand-pink peer-focus-visible:ring-offset-2",
           checked
             ? "border-brand-pink bg-brand-pink group-hover:border-pink-300 group-hover:bg-pink-300"
             : "border-gray-300",

--- a/src/components/Primitive/Radio/RadioOption.tsx
+++ b/src/components/Primitive/Radio/RadioOption.tsx
@@ -18,6 +18,12 @@ export const RadioOption = ({ option, checked, toggle, name, required }: RadioOp
         className="peer sr-only"
         name={name}
         onChange={() => toggle(option)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            toggle(option)
+          }
+        }}
         required={required}
         type="radio"
         value={option}

--- a/src/components/Primitive/Select/Select.tsx
+++ b/src/components/Primitive/Select/Select.tsx
@@ -53,6 +53,10 @@ export const Select = ({
     itemRefs: optionRefs,
   })
 
+  useEffect(() => {
+    if (isOpen) triggerRef.current?.focus()
+  }, [isOpen])
+
   const normalize = (option: SelectOption) =>
     typeof option === "string" ? { label: option, value: option } : option
 

--- a/src/components/Primitive/Select/Select.tsx
+++ b/src/components/Primitive/Select/Select.tsx
@@ -3,6 +3,7 @@
 import { ChevronDownIcon } from "@heroicons/react/24/solid"
 import { AnimatePresence, motion } from "motion/react"
 import { type Ref, useEffect, useRef, useState } from "react"
+import { usePopoverKeyboardNav } from "@/hooks/usePopoverKeyboardNav"
 import { cn } from "@/lib/utils"
 
 export type SelectOption = string | { label: string; value: string }
@@ -32,6 +33,8 @@ export const Select = ({
 }: SelectProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([])
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
@@ -42,6 +45,13 @@ export const Select = ({
     document.addEventListener("mousedown", handleMouseDown)
     return () => document.removeEventListener("mousedown", handleMouseDown)
   }, [])
+
+  const onKeyDown = usePopoverKeyboardNav({
+    isOpen,
+    onClose: () => setIsOpen(false),
+    triggerRef,
+    itemRefs: optionRefs,
+  })
 
   const normalize = (option: SelectOption) =>
     typeof option === "string" ? { label: option, value: option } : option
@@ -54,12 +64,19 @@ export const Select = ({
   }
 
   const selectControl = (
-    <div className="relative">
+    // biome-ignore lint/a11y/noStaticElementInteractions: delegates keydown from the trigger/options below to the shared popover nav handler
+    <div className="relative" onKeyDown={onKeyDown}>
       <button
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
         className="flex min-h-11 w-full items-center rounded border border-gray-300 px-3 py-2 text-left text-sm"
         id={label || undefined}
         onClick={() => setIsOpen((prev) => !prev)}
-        ref={ref}
+        ref={(el) => {
+          triggerRef.current = el
+          if (typeof ref === "function") ref(el)
+          else if (ref) ref.current = el
+        }}
         type="button"
       >
         <span className={cn("flex-1", !value && "text-gray-400")}>
@@ -79,16 +96,22 @@ export const Select = ({
             className="absolute top-full z-10 mt-1 w-full rounded border border-gray-200 bg-white py-2 shadow-md"
             exit={{ opacity: 0, y: -4 }}
             initial={{ opacity: 0, y: -4 }}
+            role="listbox"
             transition={{ damping: 25, stiffness: 400, type: "spring" }}
           >
-            {options.map(normalize).map(({ label: optLabel, value: optValue }) => (
+            {options.map(normalize).map(({ label: optLabel, value: optValue }, i) => (
               <li key={optValue}>
                 <button
+                  aria-selected={optValue === value}
                   className={cn(
                     "flex w-full items-center px-3 py-2 text-left text-sm transition-colors duration-300 hover:bg-gray-400-opaque",
                     optValue === value && "pointer-events-none bg-primary font-medium text-white",
                   )}
                   onClick={() => select(optValue)}
+                  ref={(el) => {
+                    optionRefs.current[i] = el
+                  }}
+                  role="option"
                   type="button"
                 >
                   {optLabel}

--- a/src/components/Primitive/Select/Select.tsx
+++ b/src/components/Primitive/Select/Select.tsx
@@ -65,6 +65,7 @@ export const Select = ({
   const select = (val: string) => {
     onChange(val)
     setIsOpen(false)
+    triggerRef.current?.focus()
   }
 
   const selectControl = (

--- a/src/hooks/usePopoverKeyboardNav.ts
+++ b/src/hooks/usePopoverKeyboardNav.ts
@@ -19,18 +19,24 @@ export function usePopoverKeyboardNav({
     (e: KeyboardEvent) => {
       if (!isOpen) return
 
+      if (e.key === "Escape") {
+        e.preventDefault()
+        onClose()
+        triggerRef.current?.focus()
+        return
+      }
+
       const items = itemRefs.current.filter((el): el is HTMLElement => el !== null)
       if (items.length === 0) return
 
       const currentIndex = items.indexOf(document.activeElement as HTMLElement)
+      const isOnTrackedElement =
+        currentIndex !== -1 || document.activeElement === triggerRef.current
+      if (!isOnTrackedElement) return
+
       const focus = (index: number) => items[index]?.focus()
 
       switch (e.key) {
-        case "Escape":
-          e.preventDefault()
-          onClose()
-          triggerRef.current?.focus()
-          return
         case "ArrowDown":
           e.preventDefault()
           focus(currentIndex === -1 ? 0 : (currentIndex + 1) % items.length)

--- a/src/hooks/usePopoverKeyboardNav.ts
+++ b/src/hooks/usePopoverKeyboardNav.ts
@@ -1,0 +1,60 @@
+"use client"
+
+import { type KeyboardEvent, type RefObject, useCallback } from "react"
+
+interface UsePopoverKeyboardNavOptions {
+  isOpen: boolean
+  onClose: () => void
+  triggerRef: RefObject<HTMLElement | null>
+  itemRefs: RefObject<(HTMLElement | null)[]>
+}
+
+export function usePopoverKeyboardNav({
+  isOpen,
+  onClose,
+  triggerRef,
+  itemRefs,
+}: UsePopoverKeyboardNavOptions) {
+  return useCallback(
+    (e: KeyboardEvent) => {
+      if (!isOpen) return
+
+      const items = itemRefs.current.filter((el): el is HTMLElement => el !== null)
+      if (items.length === 0) return
+
+      const currentIndex = items.indexOf(document.activeElement as HTMLElement)
+      const focus = (index: number) => items[index]?.focus()
+
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault()
+          onClose()
+          triggerRef.current?.focus()
+          return
+        case "ArrowDown":
+          e.preventDefault()
+          focus(currentIndex === -1 ? 0 : (currentIndex + 1) % items.length)
+          return
+        case "ArrowUp":
+          e.preventDefault()
+          focus(
+            currentIndex === -1
+              ? items.length - 1
+              : (currentIndex - 1 + items.length) % items.length,
+          )
+          return
+        case "Home":
+          e.preventDefault()
+          focus(0)
+          return
+        case "End":
+          e.preventDefault()
+          focus(items.length - 1)
+          return
+        default:
+          return
+      }
+    },
+    [isOpen, onClose, triggerRef, itemRefs],
+  )
+}


### PR DESCRIPTION
# Description

This PR adds comprehensive keyboard navigation support to form components, enabling users to navigate and interact with select, dropdown, and multiselect menus using keyboard shortcuts.

- introduces `usePopoverKeyboardNav` hook to handle keyboard navigation with support for Arrow Up, Arrow Down, Home, End, and Escape keys
- adds keyboard navigation integration to `Dropdown`, `MultiSelect`, and `Select` components
- improves focus management by returning focus to the trigger element when popovers close
- adds visible focus ring styling to `Radio` options for better keyboard visibility
- fixes pin input paste behavior to ignore pastes without digits
- restores accessible names on multiselect trigger and component triggers
- converts multiselect trigger from button to semantic div with proper ARIA attributes and keyboard support
- adds accessible chip removal buttons in multiselect with proper event handling

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)
