### PR TITLE
fix(build): guard postinstall against missing git binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "code:generate": "plop",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "postinstall": "lefthook install",
+    "postinstall": "sh -c 'command -v git >/dev/null 2>&1 || exit 0; lefthook install'",
     "migrate:user-admin": "tsx --env-file=.env src/scripts/user-admin-migration.ts",
     "update:google-wallet-class": "tsx --env-file=.env src/scripts/update-google-wallet-class.ts"
   },


### PR DESCRIPTION
# Description

This PR fixes the `postinstall` script to gracefully skip lefthook installation when git is not available (i.e. in Alpine-based Docker builds).

Previously, running `pnpm run build` in an Alpine-based multi-stage Dockerfile would re-trigger the `postinstall` script (even with `--ignore-scripts` in the deps stage), causing the build to fail with `exec: "git": executable file not found in $PATH` because Alpine has no git binary.

- guards the `lefthook install` command with a `command -v git` check that exits cleanly (exit 0) when git is absent
- only skips lefthook in environments without git; on systems where git is present, `lefthook install` runs unguarded so genuine errors still propagate
- prevents silent failures by not using a blanket `|| true` fallback


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
