### PR TITLE
feat(events): improve EventCard date formatting and responsive layout

### DIFF
--- a/src/components/Generic/EventCard/EventCard.tsx
+++ b/src/components/Generic/EventCard/EventCard.tsx
@@ -59,17 +59,16 @@ export const EventCard = ({ event }: EventCardProps) => {
           media
         )}
       </div>
-      <div className="flex flex-col p-2 text-center">
+      <div className="flex flex-col gap-1 p-2 text-center">
         <p className="heading-4 font-mono">{event.name.toUpperCase()}</p>
-        <p className="paragraph-xs">{event.description}</p>
-        <p className="paragraph-xs">
+        <p className="paragraph-xs text-gray-700">{event.description}</p>
+        <p className="paragraph-xs font-mono tracking-tight">
           {dayjs(event.date)
             .tz(NZ_TIMEZONE)
             .format(
-              dayjs(event.date).tz(NZ_TIMEZONE).minute() === 0
-                ? "MMMM D, YYYY h A"
-                : "MMMM D, YYYY h:mm A",
-            )}
+              dayjs(event.date).tz(NZ_TIMEZONE).minute() === 0 ? "MMMM D - hA" : "MMMM D - h:mmA",
+            )
+            .toUpperCase()}
         </p>
       </div>
     </div>

--- a/src/components/Generic/EventCard/EventCard.tsx
+++ b/src/components/Generic/EventCard/EventCard.tsx
@@ -20,6 +20,13 @@ export const EventCard = ({ event }: EventCardProps) => {
   const isUpcoming = dayjs(event.date).isAfter(dayjs())
   const canRegister = isUpcoming && Boolean(event.signUpForm)
 
+  const eventDate = dayjs(event.date).tz(NZ_TIMEZONE)
+  const dateFormat = [
+    "MMMM D",
+    ...(isUpcoming ? [] : ["YYYY"]),
+    eventDate.minute() === 0 ? "- hA" : "- h:mmA",
+  ].join(" ")
+
   const media = (
     <>
       <LazyImage
@@ -63,12 +70,7 @@ export const EventCard = ({ event }: EventCardProps) => {
         <p className="heading-4 font-mono">{event.name.toUpperCase()}</p>
         <p className="paragraph-xs text-gray-700">{event.description}</p>
         <p className="paragraph-xs font-mono tracking-tight">
-          {dayjs(event.date)
-            .tz(NZ_TIMEZONE)
-            .format(
-              dayjs(event.date).tz(NZ_TIMEZONE).minute() === 0 ? "MMMM D - hA" : "MMMM D - h:mmA",
-            )
-            .toUpperCase()}
+          {eventDate.format(dateFormat).toUpperCase()}
         </p>
       </div>
     </div>

--- a/src/components/Generic/EventCard/EventCard.tsx
+++ b/src/components/Generic/EventCard/EventCard.tsx
@@ -43,7 +43,7 @@ export const EventCard = ({ event }: EventCardProps) => {
   )
 
   return (
-    <div className="relative flex w-full max-w-2xs flex-col justify-center overflow-hidden rounded-xs shadow-md">
+    <div className="relative flex w-full max-w-56 flex-col justify-center overflow-hidden rounded-xs shadow-md md:max-w-2xs">
       <div className="group relative">
         {canRegister ? (
           <a


### PR DESCRIPTION
# Description

This PR improves the EventCard component by adding year display for past events and enhancing its responsive layout and typography.

- adds conditional year display to event dates (shows year only for past events, not upcoming ones)
- improves responsive width for the image container (`max-w-56` on mobile, `md:max-w-2xs` on medium screens and up)
- enhances text block spacing and styling with `gap-1` between elements and `text-gray-700` on the description paragraph
- refactors date formatting logic into a reusable `dateFormat` variable and applies uppercase styling with `font-mono tracking-tight` classes

Not related to a ticket

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

<img width="338" height="540" alt="Screenshot 2026-07-28 at 12 37 38" src="https://github.com/user-attachments/assets/b4dba280-cbbe-4d1f-908a-b73a67ed6220" />
<img width="312" height="491" alt="Screenshot 2026-07-28 at 12 37 49" src="https://github.com/user-attachments/assets/9e69a97f-0494-49c0-95bc-38ed3185a1f1" />
