### PR TITLE
feat(schemas): add forgot/reset password validation schemas

### DIFF
--- a/src/types/schemas/forgot-password.ts
+++ b/src/types/schemas/forgot-password.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const forgotPasswordSchema = z.object({
+  email: z.email({ error: "Please enter a valid email" }),
+})
+
+export type ForgotPasswordInput = z.input<typeof forgotPasswordSchema>
+export type ForgotPasswordOutput = z.output<typeof forgotPasswordSchema>

--- a/src/types/schemas/reset-password.ts
+++ b/src/types/schemas/reset-password.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+import { passwordMismatchIssue, passwordsMatch } from "@/types/schemas/shared"
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine(passwordsMatch, passwordMismatchIssue)
+
+export type ResetPasswordInput = z.input<typeof resetPasswordSchema>
+export type ResetPasswordOutput = z.output<typeof resetPasswordSchema>

--- a/src/types/schemas/shared.ts
+++ b/src/types/schemas/shared.ts
@@ -1,0 +1,7 @@
+export const passwordsMatch = (data: { password: string; confirmPassword: string }) =>
+  data.password === data.confirmPassword
+
+export const passwordMismatchIssue = {
+  message: "Passwords do not match",
+  path: ["confirmPassword"],
+}

--- a/src/types/schemas/user.ts
+++ b/src/types/schemas/user.ts
@@ -1,5 +1,6 @@
 import type { User } from "better-auth"
 import { z } from "zod"
+import { passwordMismatchIssue, passwordsMatch } from "@/types/schemas/shared"
 
 export const createUserServerSchema = z.object({
   firstName: z.string().min(1, "First Name is required"),
@@ -10,10 +11,7 @@ export const createUserServerSchema = z.object({
 
 export const createUserSchema = createUserServerSchema
   .extend({ confirmPassword: z.string().min(1, "Please confirm your password") })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  })
+  .refine(passwordsMatch, passwordMismatchIssue)
 
 export type CreateUserInput = z.infer<typeof createUserServerSchema>
 


### PR DESCRIPTION
# Description

This PR adds the zod schemas needed for the forgot/reset password flow.

- adds `forgotPasswordSchema` for the forgot-password form (email only)
- adds `resetPasswordSchema` for the reset-password form (`password` + `confirmPassword`)
- adds a shared `passwordsMatch` refine function and `passwordMismatchIssue` in `src/types/schemas/shared.ts`
  - `createUserServerSchema` in `user.ts` is updated to reuse these instead of its own inline `.refine()`, so the "passwords do not match" check stays consistent across all three forms

Not related to a ticket

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Base PR in a stack — schemas only, no UI to screenshot. Verified with `pnpm types:check`. Validation behaviour is covered by testing the forms in the follow-up PRs in this stack.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member
