### PR TITLE
feat(auth): wire up better-auth password reset with Payload email

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth"
 import { mongodbAdapter } from "better-auth/adapters/mongodb"
 import { mongoClient } from "@/lib/mongo"
+import { PayloadEmailService } from "@/services/email/payload-email.service"
 
 if (!process.env.BETTER_AUTH_SECRET || !process.env.NEXT_PUBLIC_URL) {
   const missingEnvVars = []
@@ -15,5 +16,11 @@ export const auth = betterAuth({
   database: mongodbAdapter(mongoClient.db()),
   emailAndPassword: {
     enabled: true,
+    sendResetPassword: async ({ user, url }, _request) => {
+      void PayloadEmailService.sendResetPassword(user.email, url).catch((error) => {
+        console.error("[Auth/sendResetPassword] Failed to send reset email", { error })
+      })
+    },
+    revokeSessionsOnPasswordReset: true,
   },
 })

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -8,6 +8,8 @@ export const Routes = {
   LOGIN: "/login",
   GOOGLE_WALLET: "/google-wallet",
   EVENTS: "/events",
+  FORGOT_PASSWORD: "/forgot-password",
+  RESET_PASSWORD: "/reset-password",
 } as const
 
 export type Route = (typeof Routes)[keyof typeof Routes]

--- a/src/services/email/payload-email.service.ts
+++ b/src/services/email/payload-email.service.ts
@@ -8,4 +8,29 @@ export class PayloadEmailService {
       text: `Here is your email verification code: ${code}. This code will expire in 10 minutes.`,
     })
   }
+
+  public static async sendResetPassword(email: string, url: string): Promise<unknown> {
+    return payload.sendEmail({
+      to: email,
+      subject: "UOACS - Reset Password",
+      text: `A password reset was requested for your account. Open this link to reset your password: ${url}`,
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 480px; padding: 24px; color: #1a1a1a;">
+          <h2 style="margin-bottom: 16px;">Reset your password</h2>
+          <p style="margin-bottom: 24px; line-height: 1.5;">
+            We received a request to reset your UOACS account password. Click the button below to choose a new one. This link will expire shortly.
+          </p>
+          <a
+            href="${url}"
+            style="display: inline-block; padding: 12px 24px; background-color: #1a1a1a; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold;"
+          >
+            Reset Password
+          </a>
+          <p style="margin-top: 24px; font-size: 13px; color: #666666; line-height: 1.5;">
+            If you didn't request this, you can safely ignore this email.
+          </p>
+        </div>
+      `,
+    })
+  }
 }


### PR DESCRIPTION
# Description

This PR wires up better-auth's password reset flow to actually send an email and revoke existing sessions.

- adds `sendResetPassword` to the `emailAndPassword` config in `auth.ts`, which calls the new `PayloadEmailService.sendResetPassword(email, url)`
  - the email send is fire-and-forget (`void ... .catch(...)`) so a slow/broken email provider can't block the reset request
- sets `revokeSessionsOnPasswordReset: true` so a password reset invalidates any existing sessions
- adds `PayloadEmailService.sendResetPassword`, following the same pattern as the existing email methods on that class
- adds `Routes.FORGOT_PASSWORD` (`/forgot-password`) and `Routes.RESET_PASSWORD` (`/reset-password`) constants, used by the reset email link and by the forms/pages added later in this stack

Depends on #367 for the schemas branch this stacks on.

Not related to a ticket

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

No UI in this PR. Triggered a reset request against a local instance and confirmed the email arrives via `PayloadEmailService` with a working reset link, and that existing sessions are revoked after the password is reset.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member
