### PR TITLE
feat(app): add forgot-password and reset-password routes

### DIFF
--- a/src/app/(frontend)/forgot-password/page.tsx
+++ b/src/app/(frontend)/forgot-password/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link"
+import { ForgotPasswordForm } from "@/components/Composite"
+import { Heading } from "@/components/Primitive"
+import { Routes } from "@/lib/routes"
+import { GuestOnly } from "../_components/GuestOnly"
+
+export default function ForgotPasswordPage() {
+  return (
+    <GuestOnly>
+      <div className="flex w-full flex-col justify-center gap-8 px-4">
+        <Heading className="justify-start" h={3}>
+          Forgot Password
+        </Heading>
+        <div className="flex w-full flex-col justify-center gap-4">
+          <ForgotPasswordForm />
+          <p className="paragraph-xs text-gray-500">
+            Remembered your password?{" "}
+            <Link className="underline transition-colors hover:text-gray-700" href={Routes.LOGIN}>
+              Log In
+            </Link>
+          </p>
+        </div>
+      </div>
+    </GuestOnly>
+  )
+}

--- a/src/app/(frontend)/reset-password/page.tsx
+++ b/src/app/(frontend)/reset-password/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react"
+import { ResetPasswordForm } from "@/components/Composite"
+import { Heading } from "@/components/Primitive"
+import { GuestOnly } from "../_components/GuestOnly"
+
+export default function ResetPasswordPage() {
+  return (
+    <GuestOnly>
+      <div className="flex w-full flex-col justify-center gap-8 px-4">
+        <Heading className="justify-start" h={3}>
+          Reset Password
+        </Heading>
+        <Suspense>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </GuestOnly>
+  )
+}


### PR DESCRIPTION
# Description

This PR adds the `/forgot-password` and `/reset-password` pages, completing the password reset flow.

- adds `src/app/(frontend)/forgot-password/page.tsx`, wrapping `ForgotPasswordForm` in `GuestOnly` with a link back to `/login`
- adds `src/app/(frontend)/reset-password/page.tsx`, wrapping `ResetPasswordForm` in `GuestOnly` and `Suspense` (needed since the form reads `useSearchParams()` for the reset token)

Depends on #369 for the form components.

Not related to a ticket

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Ran through the full flow locally: `/login` → "Forgot Password?" → `/forgot-password` → submit email → clicked the emailed reset link → `/reset-password?token=...` → set new password → redirected to `/login` and signed in with the new password. Also checked the invalid-token case by hitting `/reset-password` with no token.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I've requested a review from another team member
