### PR TITLE
chore(event-card): add ordinal suffixes to date display

### DIFF
--- a/src/components/Generic/EventCard/EventCard.tsx
+++ b/src/components/Generic/EventCard/EventCard.tsx
@@ -1,4 +1,5 @@
 import dayjs from "dayjs"
+import advancedFormat from "dayjs/plugin/advancedFormat"
 import timezone from "dayjs/plugin/timezone"
 import utc from "dayjs/plugin/utc"
 import { LazyImage } from "@/components/Primitive"
@@ -7,6 +8,7 @@ import type { Event, Media } from "@/payload/payload-types"
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+dayjs.extend(advancedFormat)
 
 const NZ_TIMEZONE = "Pacific/Auckland"
 
@@ -22,7 +24,7 @@ export const EventCard = ({ event }: EventCardProps) => {
 
   const eventDate = dayjs(event.date).tz(NZ_TIMEZONE)
   const dateFormat = [
-    "MMMM D",
+    "MMMM Do",
     ...(isUpcoming ? [] : ["YYYY"]),
     eventDate.minute() === 0 ? "- hA" : "- h:mmA",
   ].join(" ")


### PR DESCRIPTION
# Description

Adds ordinal suffixes (st, nd, rd, th) to the date display in the `EventCard` component.

- imports and extends dayjs with the `advancedFormat` plugin
- updates the date format in `EventCard.tsx` to use the `Do` token for ordinal day numbers

Not related to a ticket.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Unit/Integration tests written (requires checks to pass)

Navigated to the events section and verified event dates now display with ordinal suffixes instead of plain numbers.

Before: August 23, 2024 - 6:30PM
After: August 23rd, 2024 - 6:30PM

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I've requested a review from another team member
