### PR TITLE
feat(auth): route forgot-password through custom API endpoint to handle partial members

### DIFF
--- a/src/app/api/forgot-password/route.ts
+++ b/src/app/api/forgot-password/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server"
+import { ZodError } from "zod"
+import { auth } from "@/lib/auth/auth"
+import { Routes } from "@/lib/routes"
+import { AuthService } from "@/services/auth.service"
+import { PayloadEmailService } from "@/services/email/payload-email.service"
+import { forgotPasswordSchema } from "@/types/schemas/forgot-password"
+
+export async function POST(request: Request) {
+  const authService = new AuthService()
+
+  let email: string
+  try {
+    const body = await request.json()
+    ;({ email } = forgotPasswordSchema.parse(body))
+  } catch (err) {
+    if (err instanceof SyntaxError || err instanceof ZodError) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+    }
+    console.error("[POST /api/forgot-password] Unexpected error parsing request body", {
+      error: err,
+    })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+
+  let step: "checkMember" | "sendCompleteSignUp" | "requestPasswordReset" = "checkMember"
+  try {
+    const hasUnlinkedMember = await authService.checkMemberExists(email)
+
+    // Members created before Better Auth sign-up existed have no linked account
+    // so Better Auth's own reset flow silently no-ops for them.
+    if (hasUnlinkedMember) {
+      step = "sendCompleteSignUp"
+      const url = `${process.env.NEXT_PUBLIC_URL}${Routes.SIGN_UP}`
+      await PayloadEmailService.sendCompleteSignUp(email, url)
+    } else {
+      step = "requestPasswordReset"
+      await auth.api.requestPasswordReset({
+        body: { email, redirectTo: Routes.RESET_PASSWORD },
+      })
+    }
+  } catch (error) {
+    console.error("[POST /api/forgot-password] Failed to process request", { email, step, error })
+    return NextResponse.json(
+      { error: "An error occurred while processing your request" },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({
+    message: "If an account exists for that email, we've sent a link to continue.",
+  })
+}

--- a/src/components/Composite/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/Composite/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -5,8 +5,8 @@ import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { Button } from "@/components/Primitive"
 import { Input } from "@/components/Primitive/Input/Input"
-import { authClient } from "@/lib/auth/auth-client"
-import { Routes } from "@/lib/routes"
+import { api } from "@/lib/api/api-client"
+import { ApiRoutes } from "@/lib/routes"
 import { toast } from "@/lib/toast"
 import {
   type ForgotPasswordInput,
@@ -28,18 +28,7 @@ export const ForgotPasswordForm = () => {
   const onSubmit = async (data: ForgotPasswordOutput) => {
     setLoading(true)
     try {
-      const { error: resetRequestError } = await authClient.requestPasswordReset({
-        email: data.email,
-        redirectTo: Routes.RESET_PASSWORD,
-      })
-
-      if (resetRequestError) {
-        toast.error({
-          description: "An error occurred while requesting a password reset",
-        })
-        return
-      }
-
+      await api.post(ApiRoutes.FORGOT_PASSWORD, { email: data.email }, { toastOnError: false })
       setSubmitted(true)
     } catch (error) {
       console.error("[ForgotPasswordForm] Failed to request password reset", { error })

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -25,6 +25,7 @@ export const ApiRoutes = {
     ROOT: "/api/sign-up",
     VERIFICATION_CODE: "/api/sign-up/verification-code",
   } as const,
+  FORGOT_PASSWORD: "/api/forgot-password",
   HEALTH: "/api/health",
   EVENTS: (upcoming: boolean, page: number) => `/api/events?upcoming=${upcoming}&page=${page}`,
   GOOGLE_WALLET: {

--- a/src/services/email/payload-email.service.ts
+++ b/src/services/email/payload-email.service.ts
@@ -23,6 +23,31 @@ export class PayloadEmailService {
     })
   }
 
+  public static async sendCompleteSignUp(email: string, url: string): Promise<unknown> {
+    return payload.sendEmail({
+      to: email,
+      subject: "UOACS - Finish setting up your account",
+      text: `We found a UOACS membership for this email, but it doesn't have a password set up yet. Open this link to finish creating your account: ${url}`,
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 480px; padding: 24px; color: #1a1a1a;">
+          <h2 style="margin-bottom: 16px;">Finish setting up your account</h2>
+          <p style="margin-bottom: 24px; line-height: 1.5;">
+            We found a UOACS membership for this email, but it doesn't have a password set up yet. Click the button below to finish creating your account.
+          </p>
+          <a
+            href="${url}"
+            style="display: inline-block; padding: 12px 24px; background-color: #1a1a1a; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold;"
+          >
+            Finish Sign Up
+          </a>
+          <p style="margin-top: 24px; font-size: 13px; color: #666666; line-height: 1.5;">
+            If you didn't request this, you can safely ignore this email.
+          </p>
+        </div>
+      `,
+    })
+  }
+
   public static async sendResetPassword(email: string, url: string): Promise<unknown> {
     return payload.sendEmail({
       to: email,


### PR DESCRIPTION
# Description

This PR routes the forgot-password flow through a custom API endpoint to support legacy members without linked auth accounts.

- adds new `/api/forgot-password` endpoint that intelligently handles two scenarios:
  - members without a linked auth account receive a "Finish setting up your account" email (these are members created before Better Auth existed)
  - members with existing accounts receive a standard password-reset email via Better Auth
- updates `ForgotPasswordForm` to call `api.post(ApiRoutes.FORGOT_PASSWORD, ...)` instead of calling `authClient.requestPasswordReset` directly, centralizing the logic in the API layer
- adds `ApiRoutes.FORGOT_PASSWORD` constant to `src/lib/routes.ts`
- adds `sendCompleteSignUp()` method to `PayloadEmailService` to send the account-completion email with styled HTML

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## How to test this change

Navigate to `/forgot-password` and test both flows:

> [!WARNING]
> Note that you will likely have to delete your current account (with auth from within the record details page) and create a new one without a better-auth-id by using the payload admin GUI

1. **Legacy member (no linked auth):**
   - Use an email that exists as a member but was created before Better Auth sign-up was available
   - Submit the form and verify a "Finish setting up your account" email is received
   - Click the link and verify it directs to `/sign-up` to complete account setup

2. **Regular member (existing auth):**
   - Use an email with an existing auth account
   - Submit the form and verify a standard "Reset Password" email is received
   - Click the link and verify it directs to `/reset-password` as expected

Both flows should show the same success message: "If an account exists for that email, we've sent a link to continue."